### PR TITLE
changes to add bidder specific parameters to the prebid ext

### DIFF
--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -309,24 +309,24 @@ func getBidderParam(request *openrtb.BidRequest, key string) ([]byte, error) {
 		return nil, err
 	}
 
-	if reqExt.Prebid.Ext == nil {
+	if reqExt.Prebid.BidderParams == nil {
 		return nil, nil
 	}
 
-	bidderExt, ok := reqExt.Prebid.Ext.(map[string]interface{})
+	bidderParams, ok := reqExt.Prebid.BidderParams.(map[string]interface{})
 	if !ok {
-		err := fmt.Errorf("%s Error retrieving request.ext.prebid.ext: %v", PUBMATIC, reqExt.Prebid.Ext)
+		err := fmt.Errorf("%s Error retrieving request.ext.prebid.ext: %v", PUBMATIC, reqExt.Prebid.BidderParams)
 		return nil, err
 	}
 
-	iface, ok := bidderExt[key]
+	iface, ok := bidderParams[key]
 	if !ok {
 		return nil, nil
 	}
 
 	bytes, err := json.Marshal(iface)
 	if err != nil {
-		err := fmt.Errorf("%s Error retrieving '%s' from request.ext.prebid.ext: %v", PUBMATIC, key, bidderExt)
+		err := fmt.Errorf("%s Error retrieving '%s' from request.ext.prebid.ext: %v", PUBMATIC, key, bidderParams)
 		return nil, err
 	}
 

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -21,6 +21,7 @@ import (
 )
 
 const MAX_IMPRESSIONS_PUBMATIC = 30
+const PUBMATIC = "[PUBMATIC]"
 
 type PubmaticAdapter struct {
 	http *adapters.HTTPAdapter
@@ -60,8 +61,8 @@ const (
 )
 
 func PrepareLogMessage(tID, pubId, adUnitId, bidID, details string, args ...interface{}) string {
-	return fmt.Sprintf("[PUBMATIC] ReqID [%s] PubID [%s] AdUnit [%s] BidID [%s] %s \n",
-		tID, pubId, adUnitId, bidID, details)
+	return fmt.Sprintf("%s ReqID [%s] PubID [%s] AdUnit [%s] BidID [%s] %s \n",
+		PUBMATIC, tID, pubId, adUnitId, bidID, details)
 }
 
 func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder *pbs.PBSBidder) (pbs.PBSBidSlice, error) {
@@ -69,7 +70,7 @@ func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 	pbReq, err := adapters.MakeOpenRTBGeneric(req, bidder, a.Name(), mediaTypes)
 
 	if err != nil {
-		logf("[PUBMATIC] Failed to make ortb request for request id [%s] \n", pbReq.ID)
+		logf("%s Failed to make ortb request for request id [%s] \n", PUBMATIC, pbReq.ID)
 		return nil, err
 	}
 
@@ -78,8 +79,8 @@ func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 	pubId := ""
 	wrapExt := ""
 	if len(bidder.AdUnits) > MAX_IMPRESSIONS_PUBMATIC {
-		logf("[PUBMATIC] First %d impressions will be considered from request tid %s\n",
-			MAX_IMPRESSIONS_PUBMATIC, pbReq.ID)
+		logf("%s First %d impressions will be considered from request tid %s\n",
+			PUBMATIC, MAX_IMPRESSIONS_PUBMATIC, pbReq.ID)
 	}
 
 	for i, unit := range bidder.AdUnits {
@@ -292,12 +293,64 @@ func (a *PubmaticAdapter) Call(ctx context.Context, req *pbs.PBSRequest, bidder 
 			pbid.CreativeMediaType = string(mediaType)
 
 			bids = append(bids, &pbid)
-			logf("[PUBMATIC] Returned Bid for PubID [%s] AdUnit [%s] BidID [%s] Size [%dx%d] Price [%f] \n",
-				pubId, pbid.AdUnitCode, pbid.BidID, pbid.Width, pbid.Height, pbid.Price)
+			logf("%s Returned Bid for PubID [%s] AdUnit [%s] BidID [%s] Size [%dx%d] Price [%f] \n",
+				PUBMATIC, pubId, pbid.AdUnitCode, pbid.BidID, pbid.Width, pbid.Height, pbid.Price)
 		}
 	}
 
 	return bids, nil
+}
+
+func getBidderParam(request *openrtb.BidRequest, key string) ([]byte, error) {
+	var reqExt openrtb_ext.ExtRequest
+	err := json.Unmarshal(request.Ext, &reqExt)
+	if err != nil {
+		err := fmt.Errorf("%s Error unmarshalling request.ext: %v", PUBMATIC, string(request.Ext))
+		return nil, err
+	}
+
+	if reqExt.Prebid.Ext == nil {
+		return nil, nil
+	}
+
+	bidderExt, ok := reqExt.Prebid.Ext.(map[string]interface{})
+	if !ok {
+		err := fmt.Errorf("%s Error retrieving request.ext.prebid.ext: %v", PUBMATIC, reqExt.Prebid.Ext)
+		return nil, err
+	}
+
+	iface, ok := bidderExt[key]
+	if !ok {
+		return nil, nil
+	}
+
+	bytes, err := json.Marshal(iface)
+	if err != nil {
+		err := fmt.Errorf("%s Error retrieving '%s' from request.ext.prebid.ext: %v", PUBMATIC, key, bidderExt)
+		return nil, err
+	}
+
+	return bytes, nil
+}
+
+func getCookiesFromRequest(request *openrtb.BidRequest) ([]string, error) {
+	cbytes, err := getBidderParam(request, "Cookie")
+	if err != nil {
+		return nil, err
+	}
+
+	if cbytes == nil {
+		return nil, nil
+	}
+
+	var cookies []string
+	err = json.Unmarshal(cbytes, &cookies)
+	if err != nil {
+		err := fmt.Errorf("%s Error unmarshalling retrieving cookies from request.ext.prebid.ext: %v", PUBMATIC, string(cbytes))
+		return nil, err
+	}
+
+	return cookies, nil
 }
 
 func (a *PubmaticAdapter) MakeRequests(request *openrtb.BidRequest) ([]*adapters.RequestData, []error) {
@@ -306,6 +359,11 @@ func (a *PubmaticAdapter) MakeRequests(request *openrtb.BidRequest) ([]*adapters
 	var err error
 	wrapExt := ""
 	pubID := ""
+
+	cookies, err := getCookiesFromRequest(request)
+	if err != nil {
+		errs = append(errs, err)
+	}
 
 	for i := 0; i < len(request.Imp); i++ {
 		err = parseImpressionObject(&request.Imp[i], &wrapExt, &pubID)
@@ -364,6 +422,9 @@ func (a *PubmaticAdapter) MakeRequests(request *openrtb.BidRequest) ([]*adapters
 	headers := http.Header{}
 	headers.Add("Content-Type", "application/json;charset=utf-8")
 	headers.Add("Accept", "application/json")
+	for _, line := range cookies {
+		headers.Add("Cookie", line)
+	}
 
 	return []*adapters.RequestData{{
 		Method:  "POST",

--- a/exchange/utils.go
+++ b/exchange/utils.go
@@ -36,22 +36,22 @@ func getBidderExts(reqExt *openrtb_ext.ExtRequest) (map[string]map[string]interf
 		return nil, nil
 	}
 
-	if reqExt.Prebid.Ext == nil {
+	if reqExt.Prebid.BidderParams == nil {
 		return nil, nil
 	}
 
-	ext, err := json.Marshal(reqExt.Prebid.Ext)
+	pbytes, err := json.Marshal(reqExt.Prebid.BidderParams)
 	if err != nil {
 		return nil, err
 	}
 
-	var bidderExt map[string]map[string]interface{}
-	err = json.Unmarshal(ext, &bidderExt)
+	var bidderParams map[string]map[string]interface{}
+	err = json.Unmarshal(pbytes, &bidderParams)
 	if err != nil {
 		return nil, err
 	}
 
-	return bidderExt, nil
+	return bidderParams, nil
 }
 
 func splitBidRequest(req *openrtb.BidRequest, impsByBidder map[string][]openrtb.Imp, aliases map[string]string, usersyncs IdFetcher, blabels map[openrtb_ext.BidderName]*pbsmetrics.AdapterLabels, labels pbsmetrics.Labels) (map[openrtb_ext.BidderName]*openrtb.BidRequest, []error) {
@@ -95,9 +95,9 @@ func splitBidRequest(req *openrtb.BidRequest, impsByBidder map[string][]openrtb.
 		if len(bidderExt) != 0 {
 			bidderName := openrtb_ext.BidderName(bidder)
 			if bidderParams, ok := bidderExt[string(bidderName)]; ok {
-				reqExt.Prebid.Ext = bidderParams
+				reqExt.Prebid.BidderParams = bidderParams
 			} else {
-				reqExt.Prebid.Ext = nil
+				reqExt.Prebid.BidderParams = nil
 			}
 
 			if reqCopy.Ext, err = json.Marshal(&reqExt); err != nil {

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -7,7 +7,7 @@ import (
 
 // ExtRequest defines the contract for bidrequest.ext
 type ExtRequest struct {
-	Prebid        ExtRequestPrebid       `json:"prebid"`
+	Prebid ExtRequestPrebid `json:"prebid"`
 }
 
 // ExtRequestPrebid defines the contract for bidrequest.ext.prebid
@@ -18,6 +18,7 @@ type ExtRequestPrebid struct {
 	StoredRequest        *ExtStoredRequest      `json:"storedrequest,omitempty"`
 	Targeting            *ExtRequestTargeting   `json:"targeting,omitempty"`
 	Debug                int                    `json:"debug,omitempty"`
+	Ext                  interface{}            `json:"ext"`
 }
 
 // ExtRequestPrebidCache defines the contract for bidrequest.ext.prebid.cache

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -18,7 +18,7 @@ type ExtRequestPrebid struct {
 	StoredRequest        *ExtStoredRequest      `json:"storedrequest,omitempty"`
 	Targeting            *ExtRequestTargeting   `json:"targeting,omitempty"`
 	Debug                int                    `json:"debug,omitempty"`
-	Ext                  interface{}            `json:"ext"`
+	Ext                  interface{}            `json:"ext,omitempty"`
 }
 
 // ExtRequestPrebidCache defines the contract for bidrequest.ext.prebid.cache

--- a/openrtb_ext/request.go
+++ b/openrtb_ext/request.go
@@ -18,7 +18,7 @@ type ExtRequestPrebid struct {
 	StoredRequest        *ExtStoredRequest      `json:"storedrequest,omitempty"`
 	Targeting            *ExtRequestTargeting   `json:"targeting,omitempty"`
 	Debug                int                    `json:"debug,omitempty"`
-	Ext                  interface{}            `json:"ext,omitempty"`
+	BidderParams         interface{}            `json:"bidderparams,omitempty"`
 }
 
 // ExtRequestPrebidCache defines the contract for bidrequest.ext.prebid.cache


### PR DESCRIPTION
added an ext object to prebid ext to store bidder specific key, value objects. Parse the generic request to filter and allocate bidder parameter to that bidder request only. retrieve pubmatic specific param and send it via header to pubmatic adserver