### PR TITLE
OTT-45: Added logger and prometheus metrics to capture bid.id collisions

### DIFF
--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -315,6 +315,7 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 	adapterExtra := make(map[openrtb_ext.BidderName]*seatResponseExtra, len(cleanRequests))
 	chBids := make(chan *bidResponseWrapper, len(cleanRequests))
 	bidsFound := false
+	bidIDsCollision := false
 
 	for bidderName, req := range cleanRequests {
 		// Here we actually call the adapters and collect the bids.
@@ -383,9 +384,13 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 
 		if !bidsFound && adapterBids[brw.bidder] != nil && len(adapterBids[brw.bidder].bids) > 0 {
 			bidsFound = true
+			bidIDsCollision = recordAdaptorDuplicateBidIDs(e.me, adapterBids)
 		}
 	}
-
+	if bidIDsCollision {
+		// record this request count this request if bid collision is detected
+		e.me.RecordRequestHavingDuplicateBidID()
+	}
 	return adapterBids, adapterExtra, bidsFound
 }
 
@@ -822,4 +827,24 @@ func listBiddersWithRequests(cleanRequests map[openrtb_ext.BidderName]*openrtb.B
 	randomizeList(liveAdapters)
 
 	return liveAdapters
+}
+
+// recordAdaptorDuplicateBidIDs finds the bid.id collisions for each bidder and records them with metrics engine
+// it returns true if collosion(s) is/are detected in any of the bidder's bids
+func recordAdaptorDuplicateBidIDs(metricsEngine pbsmetrics.MetricsEngine, adapterBids map[openrtb_ext.BidderName]*pbsOrtbSeatBid) bool {
+	bidIDCollisionFound := false
+	for bidder, bid := range adapterBids {
+		bidIDColisionMap := make(map[string]int, len(adapterBids[bidder].bids))
+		for _, thisBid := range bid.bids {
+			if collisions, ok := bidIDColisionMap[thisBid.bid.ID]; ok {
+				bidIDCollisionFound = true
+				bidIDColisionMap[thisBid.bid.ID]++
+				glog.Warningf("Bid.id %v :: %v collision(s) [imp.id = %v] for bidder '%v'", thisBid.bid.ID, collisions, thisBid.bid.ImpID, string(bidder))
+				metricsEngine.RecordAdapterDuplicateBidID(string(bidder), 1)
+			} else {
+				bidIDColisionMap[thisBid.bid.ID] = 1
+			}
+		}
+	}
+	return bidIDCollisionFound
 }

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -833,6 +833,9 @@ func listBiddersWithRequests(cleanRequests map[openrtb_ext.BidderName]*openrtb.B
 // it returns true if collosion(s) is/are detected in any of the bidder's bids
 func recordAdaptorDuplicateBidIDs(metricsEngine pbsmetrics.MetricsEngine, adapterBids map[openrtb_ext.BidderName]*pbsOrtbSeatBid) bool {
 	bidIDCollisionFound := false
+	if nil == adapterBids {
+		return false
+	}
 	for bidder, bid := range adapterBids {
 		bidIDColisionMap := make(map[string]int, len(adapterBids[bidder].bids))
 		for _, thisBid := range bid.bids {

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -1639,6 +1639,47 @@ func TestUpdateHbPbCatDur(t *testing.T) {
 	}
 }
 
+func TestRecordAdaptorDuplicateBidIDs(t *testing.T) {
+	type bidderCollisions = map[string]int
+	testCases := []struct {
+		scenario         string
+		bidderCollisions bidderCollisions // represents no of collisions detected for bid.id at bidder level for given request
+		hasCollision     bool
+	}{
+		{scenario: "invalid collision value", bidderCollisions: map[string]int{"bidder-1": -1}, hasCollision: false},
+		{scenario: "no collision", bidderCollisions: map[string]int{"bidder-1": 0}, hasCollision: false},
+		{scenario: "one collision", bidderCollisions: map[string]int{"bidder-1": 1}, hasCollision: false},
+		{scenario: "multiple collisions", bidderCollisions: map[string]int{"bidder-1": 2}, hasCollision: true}, // when 2 collisions it counter will be 1
+		{scenario: "multiple bidders", bidderCollisions: map[string]int{"bidder-1": 2, "bidder-2": 4}, hasCollision: true},
+		{scenario: "multiple bidders with bidder-1 no collision", bidderCollisions: map[string]int{"bidder-1": 1, "bidder-2": 4}, hasCollision: true},
+	}
+	// expected request count when collision was detected
+	// expectedRequestCntWhereCollisionDetected := 3
+	testEngine := metricsConf.NewMetricsEngine(&config.Configuration{}, nil)
+
+	for _, testcase := range testCases {
+		adapterBids := make(map[openrtb_ext.BidderName]*pbsOrtbSeatBid)
+		for bidder, collisions := range testcase.bidderCollisions {
+			bids := make([]*pbsOrtbBid, 0)
+			testBidID := "bid_id_for_bidder_" + bidder
+			// add bids as per collisions value
+			bidCount := 0
+			for ; bidCount < collisions; bidCount++ {
+				bids = append(bids, &pbsOrtbBid{
+					bid: &openrtb.Bid{
+						ID: testBidID,
+					},
+				})
+			}
+			if nil == adapterBids[openrtb_ext.BidderName(bidder)] {
+				adapterBids[openrtb_ext.BidderName(bidder)] = new(pbsOrtbSeatBid)
+			}
+			adapterBids[openrtb_ext.BidderName(bidder)].bids = bids
+		}
+		assert.Equal(t, testcase.hasCollision, recordAdaptorDuplicateBidIDs(testEngine, adapterBids))
+	}
+}
+
 type exchangeSpec struct {
 	IncomingRequest  exchangeRequest        `json:"incomingRequest"`
 	OutgoingRequests map[string]*bidderSpec `json:"outgoingRequests"`

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -1643,23 +1643,26 @@ func TestRecordAdaptorDuplicateBidIDs(t *testing.T) {
 	type bidderCollisions = map[string]int
 	testCases := []struct {
 		scenario         string
-		bidderCollisions bidderCollisions // represents no of collisions detected for bid.id at bidder level for given request
+		bidderCollisions *bidderCollisions // represents no of collisions detected for bid.id at bidder level for given request
 		hasCollision     bool
 	}{
-		{scenario: "invalid collision value", bidderCollisions: map[string]int{"bidder-1": -1}, hasCollision: false},
-		{scenario: "no collision", bidderCollisions: map[string]int{"bidder-1": 0}, hasCollision: false},
-		{scenario: "one collision", bidderCollisions: map[string]int{"bidder-1": 1}, hasCollision: false},
-		{scenario: "multiple collisions", bidderCollisions: map[string]int{"bidder-1": 2}, hasCollision: true}, // when 2 collisions it counter will be 1
-		{scenario: "multiple bidders", bidderCollisions: map[string]int{"bidder-1": 2, "bidder-2": 4}, hasCollision: true},
-		{scenario: "multiple bidders with bidder-1 no collision", bidderCollisions: map[string]int{"bidder-1": 1, "bidder-2": 4}, hasCollision: true},
+		{scenario: "invalid collision value", bidderCollisions: &map[string]int{"bidder-1": -1}, hasCollision: false},
+		{scenario: "no collision", bidderCollisions: &map[string]int{"bidder-1": 0}, hasCollision: false},
+		{scenario: "one collision", bidderCollisions: &map[string]int{"bidder-1": 1}, hasCollision: false},
+		{scenario: "multiple collisions", bidderCollisions: &map[string]int{"bidder-1": 2}, hasCollision: true}, // when 2 collisions it counter will be 1
+		{scenario: "multiple bidders", bidderCollisions: &map[string]int{"bidder-1": 2, "bidder-2": 4}, hasCollision: true},
+		{scenario: "multiple bidders with bidder-1 no collision", bidderCollisions: &map[string]int{"bidder-1": 1, "bidder-2": 4}, hasCollision: true},
+		{scenario: "no bidders", bidderCollisions: nil, hasCollision: false},
 	}
-	// expected request count when collision was detected
-	// expectedRequestCntWhereCollisionDetected := 3
 	testEngine := metricsConf.NewMetricsEngine(&config.Configuration{}, nil)
 
 	for _, testcase := range testCases {
-		adapterBids := make(map[openrtb_ext.BidderName]*pbsOrtbSeatBid)
-		for bidder, collisions := range testcase.bidderCollisions {
+		var adapterBids map[openrtb_ext.BidderName]*pbsOrtbSeatBid
+		if nil == testcase.bidderCollisions {
+			break
+		}
+		adapterBids = make(map[openrtb_ext.BidderName]*pbsOrtbSeatBid)
+		for bidder, collisions := range *testcase.bidderCollisions {
 			bids := make([]*pbsOrtbBid, 0)
 			testBidID := "bid_id_for_bidder_" + bidder
 			// add bids as per collisions value

--- a/pbsmetrics/config/metrics.go
+++ b/pbsmetrics/config/metrics.go
@@ -195,6 +195,20 @@ func (me *MultiMetricsEngine) RecordTimeoutNotice(success bool) {
 	}
 }
 
+// RecordAdapterDuplicateBidID across all engines
+func (me *MultiMetricsEngine) RecordAdapterDuplicateBidID(adaptor string, collisions int) {
+	for _, thisME := range *me {
+		thisME.RecordAdapterDuplicateBidID(adaptor, collisions)
+	}
+}
+
+// RecordRequestHavingDuplicateBidID across all engines
+func (me *MultiMetricsEngine) RecordRequestHavingDuplicateBidID() {
+	for _, thisME := range *me {
+		thisME.RecordRequestHavingDuplicateBidID()
+	}
+}
+
 // DummyMetricsEngine is a Noop metrics engine in case no metrics are configured. (may also be useful for tests)
 type DummyMetricsEngine struct{}
 
@@ -272,4 +286,12 @@ func (me *DummyMetricsEngine) RecordRequestQueueTime(success bool, requestType p
 
 // RecordTimeoutNotice as a noop
 func (me *DummyMetricsEngine) RecordTimeoutNotice(success bool) {
+}
+
+// RecordAdapterDuplicateBidID as a noop
+func (me *DummyMetricsEngine) RecordAdapterDuplicateBidID(adaptor string, collisions int) {
+}
+
+// RecordRequestHavingDuplicateBidID as a noop
+func (me *DummyMetricsEngine) RecordRequestHavingDuplicateBidID() {
 }

--- a/pbsmetrics/go_metrics.go
+++ b/pbsmetrics/go_metrics.go
@@ -562,6 +562,14 @@ func (me *Metrics) RecordTimeoutNotice(success bool) {
 	return
 }
 
+// RecordAdapterDuplicateBidID as noop
+func (me *Metrics) RecordAdapterDuplicateBidID(adaptor string, collisions int) {
+}
+
+// RecordRequestHavingDuplicateBidID as noop
+func (me *Metrics) RecordRequestHavingDuplicateBidID() {
+}
+
 func doMark(bidder openrtb_ext.BidderName, meters map[openrtb_ext.BidderName]metrics.Meter) {
 	met, ok := meters[bidder]
 	if ok {

--- a/pbsmetrics/metrics.go
+++ b/pbsmetrics/metrics.go
@@ -276,4 +276,11 @@ type MetricsEngine interface {
 	RecordPrebidCacheRequestTime(success bool, length time.Duration)
 	RecordRequestQueueTime(success bool, requestType RequestType, length time.Duration)
 	RecordTimeoutNotice(sucess bool)
+	// RecordAdapterDuplicateBidID captures the  bid.ID collisions when adaptor
+	// gives the bid response with multiple bids containing  same bid.ID
+	RecordAdapterDuplicateBidID(adaptor string, collisions int)
+
+	// RecordRequestHavingDuplicateBidID keeps track off how many request got bid.id collision
+	// detected
+	RecordRequestHavingDuplicateBidID()
 }

--- a/pbsmetrics/metrics_mock.go
+++ b/pbsmetrics/metrics_mock.go
@@ -106,3 +106,13 @@ func (me *MetricsEngineMock) RecordRequestQueueTime(success bool, requestType Re
 func (me *MetricsEngineMock) RecordTimeoutNotice(success bool) {
 	me.Called(success)
 }
+
+// RecordAdapterDuplicateBidID mock
+func (me *MetricsEngineMock) RecordAdapterDuplicateBidID(adaptor string, collisions int) {
+	me.Called(adaptor, collisions)
+}
+
+// RecordRequestHavingDuplicateBidID mock
+func (me *MetricsEngineMock) RecordRequestHavingDuplicateBidID() {
+	me.Called()
+}

--- a/pbsmetrics/prometheus/prometheus_test.go
+++ b/pbsmetrics/prometheus/prometheus_test.go
@@ -944,6 +944,48 @@ func TestTimeoutNotifications(t *testing.T) {
 
 }
 
+// TestRecordRequestDuplicateBidID checks RecordRequestDuplicateBidID
+func TestRecordRequestDuplicateBidID(t *testing.T) {
+	m := createMetricsForTesting()
+	m.RecordRequestHavingDuplicateBidID()
+	// verify total no of requests which detected collision
+	assertCounterValue(t, "request cnt having duplicate bid.id", "request cnt having duplicate bid.id", m.requestsDuplicateBidIDCounter, float64(1))
+}
+
+// TestRecordAdapterDuplicateBidID checks RecordAdapterDuplicateBidID
+func TestRecordAdapterDuplicateBidID(t *testing.T) {
+	type collisions struct {
+		simulate int // no of bids to be simulate with same bid.id
+		expect   int // no of collisions expected to be recorded by metrics engine for given bidder
+	}
+	type bidderCollisions = map[string]collisions
+	testCases := []struct {
+		scenario         string
+		bidderCollisions bidderCollisions // represents no of collisions detected for bid.id at bidder level for given request
+		expectCollisions int
+	}{
+		{scenario: "invalid collision value", bidderCollisions: map[string]collisions{"bidder-1": {simulate: -1, expect: 0}}},
+		{scenario: "no collision", bidderCollisions: map[string]collisions{"bidder-1": {simulate: 0, expect: 0}}},
+		{scenario: "one collision", bidderCollisions: map[string]collisions{"bidder-1": {simulate: 1, expect: 1}}},
+		{scenario: "multiple collisions", bidderCollisions: map[string]collisions{"bidder-1": {simulate: 2, expect: 2}}},
+		{scenario: "multiple bidders", bidderCollisions: map[string]collisions{"bidder-1": {simulate: 2, expect: 2}, "bidder-2": {simulate: 4, expect: 4}}},
+		{scenario: "multiple bidders with bidder-1 no collision", bidderCollisions: map[string]collisions{"bidder-1": {simulate: 0, expect: 0},
+			"bidder-2": {simulate: 4, expect: 4}}},
+	}
+
+	for _, testcase := range testCases {
+		m := createMetricsForTesting()
+		for bidder, collisions := range testcase.bidderCollisions {
+			for collision := 1; collision <= collisions.simulate; collision++ {
+				m.RecordAdapterDuplicateBidID(bidder, 1)
+			}
+			assertCounterVecValue(t, testcase.scenario, testcase.scenario, m.adapterDuplicateBidIDCounter, float64(collisions.expect), prometheus.Labels{
+				adapterLabel: bidder,
+			})
+		}
+	}
+}
+
 func assertCounterValue(t *testing.T, description, name string, counter prometheus.Counter, expected float64) {
 	m := dto.Metric{}
 	counter.Write(&m)

--- a/router/router.go
+++ b/router/router.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/PubMatic-OpenWrap/prebid-server/pbsmetrics"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/PubMatic-OpenWrap/prebid-server/adapters"
 	"github.com/PubMatic-OpenWrap/prebid-server/adapters/adform"
@@ -421,4 +422,13 @@ func readDefaultRequest(defReqConfig config.DefReqConfig) (map[string]string, []
 		return aliases, defReqJSON
 	}
 	return aliases, []byte{}
+}
+
+func GetPrometheusRegistry() *prometheus.Registry {
+	mEngine, ok := g_metrics.(*metricsConf.DetailedMetricsEngine)
+	if !ok || mEngine == nil || mEngine.PrometheusMetrics == nil {
+		return nil
+	}
+
+	return mEngine.PrometheusMetrics.Registry
 }


### PR DESCRIPTION
**For OTT-45 - Using this branch to merge it to OTT-9 (Feature branch of Deal Priortization)**

-  Closed PR-https://github.com/PubMatic-OpenWrap/prebid-server/pull/79 - It was containing CI branch downmerged code. 
-  Closed PR - https://github.com/PubMatic-OpenWrap/prebid-server/pull/83 - It was created directly against CI branch. Actaully OTT-45 should following this merge path : OTT-45 -> OTT-9 -> CI

1. This branch contains changes for https://github.com/PubMatic-OpenWrap/prebid-server/pull/79 , excluding the CI branch downmerge
2. Code review for OTT-45 is already done on 21 Oct 2020 12:30 PM. comments w.r.t. https://github.com/PubMatic-OpenWrap/prebid-server/pull/79 are already addressed here and are as follows
3. Ref (https://github.com/PubMatic-OpenWrap/prebid-server/pull/79#issue-506754931)
- Added Prometheus support
- Added expected scenario inside TestRecordAdapterDuplicateBidID. (#83)
- Write separate unit tests for RecordAdapterDuplicateBidID and RecordRequestHavingDuplicateBidID

