### PR TITLE
OTT-67: Added functionality to prefer using actual video ad duration 

### DIFF
--- a/endpoints/openrtb2/ctv_auction.go
+++ b/endpoints/openrtb2/ctv_auction.go
@@ -567,7 +567,7 @@ func (deps *ctvEndpointDeps) getBids(resp *openrtb.BidResponse) {
 				impBids.Bids = append(impBids.Bids, &types.Bid{
 					Bid:               bid,
 					FilterReasonCode:  constant.CTVRCDidNotGetChance,
-					Duration:          int(deps.impData[index].Config[sequenceNumber-1].MaxDuration),
+					Duration:          getAdDuration(*bid, deps.impData[index].Config[sequenceNumber-1].MaxDuration),
 					DealTierSatisfied: util.GetDealTierSatisfied(&ext),
 				})
 			}
@@ -851,4 +851,16 @@ func getAdPodBidExtension(adpod *types.AdPodBid) json.RawMessage {
 	}
 	rawExt, _ := json.Marshal(bidExt)
 	return rawExt
+}
+
+//getAdDuration determines the duration of video ad from given bid.
+//it will try to get the actual ad duration returned by the bidder using prebid.video.duration
+//if prebid.video.duration = 0 or there is error occured in determing it then
+//impress
+func getAdDuration(bid openrtb.Bid, defaultDuration int64) int {
+	duration, err := jsonparser.GetInt(bid.Ext, "prebid", "video", "duration")
+	if nil != err || duration <= 0 {
+		duration = defaultDuration
+	}
+	return int(duration)
 }

--- a/endpoints/openrtb2/ctv_auction_test.go
+++ b/endpoints/openrtb2/ctv_auction_test.go
@@ -15,7 +15,7 @@ func TestGetAdDuration(t *testing.T) {
 		expect        int
 	}{
 		{"0sec ad duration", "0", 200, 200},
-		{"40sec ad duration", "30", 100, 30},
+		{"30sec ad duration", "30", 100, 30},
 		{"negative ad duration", "-30", 100, 100},
 		{"invalid ad duration", "invalid", 80, 80},
 		{"ad duration breaking bid.Ext json", `""quote""`, 50, 50},

--- a/endpoints/openrtb2/ctv_auction_test.go
+++ b/endpoints/openrtb2/ctv_auction_test.go
@@ -1,0 +1,31 @@
+package openrtb2
+
+import (
+	"testing"
+
+	"github.com/PubMatic-OpenWrap/openrtb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAdDuration(t *testing.T) {
+	var tests = []struct {
+		scenario      string
+		adDuration    string // actual ad duration. 0 value will be assumed as no ad duration
+		maxAdDuration int    // requested max ad duration
+		expect        int
+	}{
+		{"0sec ad duration", "0", 200, 200},
+		{"40sec ad duration", "30", 100, 30},
+		{"negative ad duration", "-30", 100, 100},
+		{"invalid ad duration", "invalid", 80, 80},
+		{"ad duration breaking bid.Ext json", `""quote""`, 50, 50},
+	}
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			bid := openrtb.Bid{
+				Ext: []byte(`{"prebid" : {"video" : {"duration" : ` + test.adDuration + `}}}`),
+			}
+			assert.Equal(t, test.expect, getAdDuration(bid, int64(test.maxAdDuration)))
+		})
+	}
+}


### PR DESCRIPTION
@pm-viral-vala : Please review and approve

Added functionality to prefer using video ad duration returned by the bidder.

If it is 0 or any error is occurred in determining it then impression-level max duration value
will be used.