### PR TITLE
OTT-71: (CI) Add stats collecting information around the actual Ad duration

### DIFF
--- a/endpoints/openrtb2/ctv/constant/constant.go
+++ b/endpoints/openrtb2/ctv/constant/constant.go
@@ -45,7 +45,7 @@ type MonitorKey string
 
 const (
 	// CombinationGeneratorV1 ...
-	CombinationGeneratorV1 MonitorKey = "comp_exclusion_v1"
+	CombinationGeneratorV1 MonitorKey = "comb_gen_v1"
 	// CompetitiveExclusionV1 ...
 	CompetitiveExclusionV1 MonitorKey = "comp_exclusion_v1"
 )

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -365,7 +365,7 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 					var cpm = float64(bid.bid.Price * 1000)
 					e.me.RecordAdapterPrice(*bidlabels, cpm)
 					e.me.RecordAdapterBidReceived(*bidlabels, bid.bidType, bid.bid.AdM != "")
-					if bid.bidType == openrtb_ext.BidTypeVideo && bid.bidVideo != nil {
+					if bid.bidType == openrtb_ext.BidTypeVideo && bid.bidVideo != nil && bid.bidVideo.Duration > 0 {
 						e.me.RecordAdapterVideoBidDuration(*bidlabels, bid.bidVideo.Duration)
 					}
 				}

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -365,6 +365,9 @@ func (e *exchange) getAllBids(ctx context.Context, cleanRequests map[openrtb_ext
 					var cpm = float64(bid.bid.Price * 1000)
 					e.me.RecordAdapterPrice(*bidlabels, cpm)
 					e.me.RecordAdapterBidReceived(*bidlabels, bid.bidType, bid.bid.AdM != "")
+					if bid.bidType == openrtb_ext.BidTypeVideo && bid.bidVideo != nil {
+						e.me.RecordAdapterVideoBidDuration(*bidlabels, bid.bidVideo.Duration)
+					}
 				}
 			}
 			chBids <- brw

--- a/pbsmetrics/config/metrics.go
+++ b/pbsmetrics/config/metrics.go
@@ -336,6 +336,6 @@ func (me *DummyMetricsEngine) RecordPodCombGenTime(labels pbsmetrics.PodLabels, 
 func (me *DummyMetricsEngine) RecordPodCompititveExclusionTime(labels pbsmetrics.PodLabels, elapsedTime time.Duration) {
 }
 
-// RecordAdapterVideoBidDuration ...
+// RecordAdapterVideoBidDuration as a noop
 func (me *DummyMetricsEngine) RecordAdapterVideoBidDuration(labels pbsmetrics.AdapterLabels, videoBidDuration int) {
 }

--- a/pbsmetrics/config/metrics.go
+++ b/pbsmetrics/config/metrics.go
@@ -230,6 +230,13 @@ func (me *MultiMetricsEngine) RecordPodCompititveExclusionTime(labels pbsmetrics
 	}
 }
 
+// RecordAdapterVideoBidDuration as a noop
+func (me *MultiMetricsEngine) RecordAdapterVideoBidDuration(labels pbsmetrics.AdapterLabels, videoBidDuration int) {
+	for _, thisME := range *me {
+		thisME.RecordAdapterVideoBidDuration(labels, videoBidDuration)
+	}
+}
+
 // DummyMetricsEngine is a Noop metrics engine in case no metrics are configured. (may also be useful for tests)
 type DummyMetricsEngine struct{}
 
@@ -309,7 +316,6 @@ func (me *DummyMetricsEngine) RecordRequestQueueTime(success bool, requestType p
 func (me *DummyMetricsEngine) RecordTimeoutNotice(success bool) {
 }
 
-
 // RecordAdapterDuplicateBidID as a noop
 func (me *DummyMetricsEngine) RecordAdapterDuplicateBidID(adaptor string, collisions int) {
 }
@@ -328,4 +334,8 @@ func (me *DummyMetricsEngine) RecordPodCombGenTime(labels pbsmetrics.PodLabels, 
 
 // RecordPodCompititveExclusionTime as a noop
 func (me *DummyMetricsEngine) RecordPodCompititveExclusionTime(labels pbsmetrics.PodLabels, elapsedTime time.Duration) {
+}
+
+// RecordAdapterVideoBidDuration ...
+func (me *DummyMetricsEngine) RecordAdapterVideoBidDuration(labels pbsmetrics.AdapterLabels, videoBidDuration int) {
 }

--- a/pbsmetrics/go_metrics.go
+++ b/pbsmetrics/go_metrics.go
@@ -582,6 +582,10 @@ func (me *Metrics) RecordPodCombGenTime(labels PodLabels, elapsedTime time.Durat
 func (me *Metrics) RecordPodCompititveExclusionTime(labels PodLabels, elapsedTime time.Duration) {
 }
 
+// RecordAdapterVideoBidDuration as a noop
+func (me *Metrics) RecordAdapterVideoBidDuration(labels AdapterLabels, videoBidDuration int) {
+}
+
 func doMark(bidder openrtb_ext.BidderName, meters map[openrtb_ext.BidderName]metrics.Meter) {
 	met, ok := meters[bidder]
 	if ok {

--- a/pbsmetrics/metrics.go
+++ b/pbsmetrics/metrics.go
@@ -315,4 +315,7 @@ type MetricsEngine interface {
 	// elapsedTime indicates the time taken by competitive exclusion to form final ad pod response using combinations and exclusion algorithm
 	// This function will take care of computing the elpased time
 	RecordPodCompititveExclusionTime(labels PodLabels, elapsedTime time.Duration)
+
+	//RecordAdapterVideoBidDuration records actual ad duration returned by the bidder
+	RecordAdapterVideoBidDuration(labels AdapterLabels, videoBidDuration int)
 }

--- a/pbsmetrics/metrics_mock.go
+++ b/pbsmetrics/metrics_mock.go
@@ -131,3 +131,8 @@ func (me *MetricsEngineMock) RecordPodCombGenTime(labels PodLabels, elapsedTime 
 func (me *MetricsEngineMock) RecordPodCompititveExclusionTime(labels PodLabels, elapsedTime time.Duration) {
 	me.Called(labels, elapsedTime)
 }
+
+//RecordAdapterVideoBidDuration mock
+func (me *MetricsEngineMock) RecordAdapterVideoBidDuration(labels AdapterLabels, videoBidDuration int) {
+	me.Called(labels, videoBidDuration)
+}

--- a/pbsmetrics/prometheus/prometheus.go
+++ b/pbsmetrics/prometheus/prometheus.go
@@ -268,8 +268,6 @@ func NewMetrics(cfg config.PrometheusMetrics) *Metrics {
 		//[]float64{0.000200000, 0.000250000, 0.000275000, 0.000300000})
 		[]float64{0.000100000, 0.000200000, 0.000300000, 0.000400000, 0.000500000, 0.000600000})
 
-	// metrics.adapterVideoBidDuration = newSummary(cfg, metrics.Registry, "adapter_vidbid_dur", "Video Ad durations returned by the bidder", []string{adapterLabel},
-	// 	map[float64]float64{1.0: 60.0})
 	metrics.adapterVideoBidDuration = newHistogram(cfg, metrics.Registry,
 		"adapter_vidbid_dur",
 		"Video Ad durations returned by the bidder", []string{adapterLabel},
@@ -314,19 +312,6 @@ func newHistogram(cfg config.PrometheusMetrics, registry *prometheus.Registry, n
 	histogram := prometheus.NewHistogramVec(opts, labels)
 	registry.MustRegister(histogram)
 	return histogram
-}
-
-func newSummary(cfg config.PrometheusMetrics, registry *prometheus.Registry, name, help string, labels []string, objectives map[float64]float64) *prometheus.SummaryVec {
-	opts := prometheus.SummaryOpts{
-		Namespace:  cfg.Namespace,
-		Subsystem:  cfg.Subsystem,
-		Name:       name,
-		Help:       help,
-		Objectives: objectives,
-	}
-	summary := prometheus.NewSummaryVec(opts, []string{adapterLabel})
-	registry.MustRegister(summary)
-	return summary
 }
 
 func (m *Metrics) RecordConnectionAccept(success bool) {

--- a/pbsmetrics/prometheus/prometheus.go
+++ b/pbsmetrics/prometheus/prometheus.go
@@ -555,7 +555,9 @@ func (m *Metrics) RecordPodCompititveExclusionTime(labels pbsmetrics.PodLabels, 
 	recordAlgoTime(m.podCompExclTimer, labels, elapsedTime)
 }
 
-//RecordAdapterVideoBidDuration records actual ad duration returned by the bidder
+//RecordAdapterVideoBidDuration records actual ad duration (>0) returned by the bidder
 func (m *Metrics) RecordAdapterVideoBidDuration(labels pbsmetrics.AdapterLabels, videoBidDuration int) {
-	m.adapterVideoBidDuration.With(prometheus.Labels{adapterLabel: string(labels.Adapter)}).Observe(float64(videoBidDuration))
+	if videoBidDuration > 0 {
+		m.adapterVideoBidDuration.With(prometheus.Labels{adapterLabel: string(labels.Adapter)}).Observe(float64(videoBidDuration))
+	}
 }

--- a/pbsmetrics/prometheus/prometheus_test.go
+++ b/pbsmetrics/prometheus/prometheus_test.go
@@ -1028,20 +1028,31 @@ func TestRecordAdapterVideoBidDuration(t *testing.T) {
 			expectedSum:   map[string]int{"bidder_1": 58},
 			expectedCount: map[string]int{"bidder_1": 4},
 			expectedBuckets: map[string]map[int]int{
-				"bidder_1": {5: 1, 10: 2, 30: 3},
+				"bidder_1": {5: 1, 10: 2, 15: 3, 35: 4}, // Upper bound : cumulative number
 			},
 		},
 		{
 			description: "multiple bidders multiple ad durations",
 			bidderAdDurations: map[string][]int{
-				"bidder_1": {5, 10, 11, 32},
+				"bidder_1": {5, 10, 11, 32, 39},
 				"bidder_2": {25, 30},
 			},
-			expectedSum:   map[string]int{"bidder_1": 58, "bidder_2": 55},
-			expectedCount: map[string]int{"bidder_1": 4, "bidder_2": 2},
+			expectedSum:   map[string]int{"bidder_1": 97, "bidder_2": 55},
+			expectedCount: map[string]int{"bidder_1": 5, "bidder_2": 2},
 			expectedBuckets: map[string]map[int]int{
-				"bidder_1": {5: 1, 10: 2, 30: 3},
+				"bidder_1": {5: 1, 10: 2, 15: 3, 35: 4, 40: 5, 41: 5},
 				"bidder_2": {25: 1, 30: 2},
+			},
+		},
+		{
+			description: "bidder with 0 ad durations",
+			bidderAdDurations: map[string][]int{
+				"bidder_1": {5, 0, 0, 27},
+			},
+			expectedSum:   map[string]int{"bidder_1": 32},
+			expectedCount: map[string]int{"bidder_1": 2}, // must exclude 2 observations having 0 durations
+			expectedBuckets: map[string]map[int]int{
+				"bidder_1": {5: 1, 30: 2},
 			},
 		},
 	}

--- a/pbsmetrics/prometheus/prometheus_test.go
+++ b/pbsmetrics/prometheus/prometheus_test.go
@@ -1014,20 +1014,35 @@ func TestRecordPodCompetitiveExclusionTime(t *testing.T) {
 func TestRecordAdapterVideoBidDuration(t *testing.T) {
 
 	testCases := []struct {
-		description           string
-		bidderAdDurations     map[string][]int
-		expectedSum           int
-		expectedCount         int
-		expectBucketsAndCount map[int]int
+		description       string
+		bidderAdDurations map[string][]int
+		expectedSum       map[string]int
+		expectedCount     map[string]int
+		expectedBuckets   map[string]map[int]int // cumulative
 	}{
 		{
 			description: "single bidder multiple ad durations",
 			bidderAdDurations: map[string][]int{
 				"bidder_1": {5, 10, 11, 32},
 			},
-			expectedSum:           58,
-			expectedCount:         4,
-			expectBucketsAndCount: map[int]int{5: 1, 10: 2, 30: 1},
+			expectedSum:   map[string]int{"bidder_1": 58},
+			expectedCount: map[string]int{"bidder_1": 4},
+			expectedBuckets: map[string]map[int]int{
+				"bidder_1": {5: 1, 10: 2, 30: 3},
+			},
+		},
+		{
+			description: "multiple bidders multiple ad durations",
+			bidderAdDurations: map[string][]int{
+				"bidder_1": {5, 10, 11, 32},
+				"bidder_2": {25, 30},
+			},
+			expectedSum:   map[string]int{"bidder_1": 58, "bidder_2": 55},
+			expectedCount: map[string]int{"bidder_1": 4, "bidder_2": 2},
+			expectedBuckets: map[string]map[int]int{
+				"bidder_1": {5: 1, 10: 2, 30: 3},
+				"bidder_2": {25: 1, 30: 2},
+			},
 		},
 	}
 
@@ -1042,12 +1057,14 @@ func TestRecordAdapterVideoBidDuration(t *testing.T) {
 				}
 				result := getHistogramFromHistogramVec(m.adapterVideoBidDuration, adapterLabel, adapterName)
 				for _, bucket := range result.GetBucket() {
-					cnt, ok := test.expectBucketsAndCount[int(bucket.GetUpperBound())]
+					cnt, ok := test.expectedBuckets[adapterName][int(bucket.GetUpperBound())]
 					if ok {
 						assert.Equal(t, uint64(cnt), bucket.GetCumulativeCount())
 					}
 				}
-				assertHistogram(t, "adapter_vidbid_dur", result, uint64(test.expectedCount), float64(test.expectedSum))
+				expectedCount := test.expectedCount[adapterName]
+				expectedSum := test.expectedSum[adapterName]
+				assertHistogram(t, "adapter_vidbid_dur", result, uint64(expectedCount), float64(expectedSum))
 			}
 		})
 	}


### PR DESCRIPTION
1. Copy of  PR-https://github.com/PubMatic-OpenWrap/prebid-server/pull/92 (Master Merge)
2. PR-https://github.com/PubMatic-OpenWrap/prebid-server/pull/92 already reviewed and approved
3. Approval - https://github.com/PubMatic-OpenWrap/prebid-server/pull/92#pullrequestreview-555144735 
4. NOTE - endpoints/openrtb2/ctv/constant/constant.go  - Though this is not part of OTT-71, allowing this change to be pushed on CI branch.
Reason:
Expected value for CombinationGeneratorV1 is comb_gen_v1
Master branch already having comb_gen_v1 - https://github.com/PubMatic-OpenWrap/prebid-server/blob/master/endpoints/openrtb2/ctv/constant/constant.go
Looks like ci branch is not in sync with master 