### PR TITLE
OTT-101: Added exchange.applyAdvertiserBlocking and unit tests around it

### DIFF
--- a/adapters/vastbidder/tagbidder_test.go
+++ b/adapters/vastbidder/tagbidder_test.go
@@ -80,6 +80,7 @@ func TestMakeRequests(t *testing.T) {
 							Ext: []byte(`{"bidder" :{}}`),
 						},
 						{
+
 							ID: "no_protocol_field_set",
 							Video: &openrtb.Video{ // vast 2 and 4.0 wrapper
 								Protocols: []openrtb.Protocol{},

--- a/adapters/vastbidder/vast_tag_response_handler.go
+++ b/adapters/vastbidder/vast_tag_response_handler.go
@@ -150,6 +150,9 @@ func (handler *VASTTagResponseHandler) vastTagToBidderResponse(internalRequest *
 		}
 	}
 
+	//getAdvertisers temporary implenmentation to make OTT-101 drop testable
+	//OTT-100 must replace this function and its integration with valid implementation
+	typedBid.Bid.ADomain = getAdvertisers(adElement)
 	//if bid.id is not set in ParseExtension
 	if len(typedBid.Bid.ID) == 0 {
 		typedBid.Bid.ID = GetRandomID()
@@ -181,6 +184,27 @@ func getAdElement(vast *etree.Element) *etree.Element {
 		return ad
 	}
 	return nil
+}
+
+//getAdvertisers temporary implenmentation to make OTT-101 drop testable
+//OTT-100 must replace this function and its integration with valid implementation
+func getAdvertisers(ad *etree.Element) []string {
+	extensions := ad.FindElements(`./Extensions/Extension/`)
+	advertisers := []string{}
+	for _, ext := range extensions {
+		for _, attr := range ext.Attr {
+			if attr.Key == "type" && attr.Value == "advertiser" {
+				for _, ele := range ext.ChildElements() {
+					if ele.Tag == "Advertiser" {
+						advertisers = append(advertisers, ele.Text())
+					}
+				}
+
+			}
+		}
+	}
+
+	return advertisers
 }
 
 func getPricingDetails(version string, ad *etree.Element) (float64, string, bool) {

--- a/adapters/vastbidder/vast_tag_response_handler.go
+++ b/adapters/vastbidder/vast_tag_response_handler.go
@@ -190,12 +190,15 @@ func getAdElement(vast *etree.Element) *etree.Element {
 //OTT-100 must replace this function and its integration with valid implementation
 func getAdvertisers(ad *etree.Element) []string {
 	extensions := ad.FindElements(`./Extensions/Extension/`)
-	advertisers := []string{}
+	var advertisers []string
 	for _, ext := range extensions {
 		for _, attr := range ext.Attr {
 			if attr.Key == "type" && attr.Value == "advertiser" {
 				for _, ele := range ext.ChildElements() {
 					if ele.Tag == "Advertiser" {
+						if nil == advertisers {
+							advertisers = make([]string, 0)
+						}
 						advertisers = append(advertisers, ele.Text())
 					}
 				}

--- a/exchange/adapter_map.go
+++ b/exchange/adapter_map.go
@@ -229,6 +229,10 @@ func newAdapterMap(client *http.Client, cfg *config.Configuration, infos adapter
 	for name, bidder := range ortbBidders {
 		// Clean out any disabled bidders
 		if infos[string(name)].Status == adapters.StatusActive {
+			if _, tagBidder := bidder.(*vastbidder.TagBidder); tagBidder {
+				// keep list of tag bidders
+				tagBidders[openrtb_ext.BidderName(name)] = bidder
+			}
 			allBidders[name] = adaptBidder(adapters.EnforceBidderInfo(bidder, infos[string(name)]), client, cfg, me, name)
 		}
 	}
@@ -255,4 +259,11 @@ func DisableBidders(biddersInfo adapters.BidderInfos, disabledBidders map[string
 	}
 
 	return bidderMap
+}
+
+// tag bidders
+var tagBidders = map[openrtb_ext.BidderName]adapters.Bidder{}
+
+var getTagBidders = func() map[openrtb_ext.BidderName]adapters.Bidder {
+	return tagBidders
 }

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -951,9 +951,11 @@ func normalizeDomain(domain string) (string, error) {
 //it returns seatbids containing valid bids and rejections containing rejected bid.id with reason
 func applyAdvertiserBlocking(bidRequest *openrtb.BidRequest, seatBids map[openrtb_ext.BidderName]*pbsOrtbSeatBid, adapterMap map[openrtb_ext.BidderName]adaptedBidder) (map[openrtb_ext.BidderName]*pbsOrtbSeatBid, []string) {
 	rejections := []string{}
-	for bidderName, seatBid := range seatBids {
-		adptedBidder := adapterMap[bidderName]
-		bidder, isBidder := adptedBidder.(*bidderAdapter) // should be non-legacy bidder
+	for bidderName, seatBid := range seatBids { // exchange.validatedBidder
+		b := adapterMap[bidderName]
+		b1, isBidder := b.(*validatedBidder) // should be non-legacy bidder
+		b2, isBidder := b1.bidder.(*bidderAdapter)
+		bidder, isBidder := b2.Bidder.(*adapters.InfoAwareBidder)
 		if isBidder {
 			// apply advertiser blocking only if bidder is tagbidder
 			_, isTagBidder := bidder.Bidder.(*vastbidder.TagBidder)

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -2704,7 +2704,7 @@ func TestApplyAdvertiserBlocking(t *testing.T) {
 			},
 			want: want{
 				rejectedBidIds:       []string{"bid_1_of_blocked_adv", "bid_2_of_blocked_adv"},
-				validBidCountPerSeat: map[string]int{"my_adapter": 0},
+				validBidCountPerSeat: map[string]int{"my_adapter": 1},
 			},
 		}, {
 			name: "multiple_badv",
@@ -2854,6 +2854,7 @@ func TestApplyAdvertiserBlocking(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			fmt.Println(tt.name)
 			seatBids := make(map[openrtb_ext.BidderName]*pbsOrtbSeatBid)
 			adapterMap := make(map[openrtb_ext.BidderName]adaptedBidder, 0)
 			for adaptor, sbids := range tt.args.adaptorSeatBids {

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -2573,6 +2573,18 @@ func TestApplyAdvertiserBlocking(t *testing.T) {
 									ADomain: []string{"b.com"},
 								},
 							},
+							{
+								bid: &openrtb.Bid{
+									ID:      "keep_ba.com",
+									ADomain: []string{"ba.com"},
+								},
+							},
+							{
+								bid: &openrtb.Bid{
+									ID:      "reject_ba.com",
+									ADomain: []string{"b.a.com.shri.com"},
+								},
+							},
 						},
 					},
 				},
@@ -2580,7 +2592,7 @@ func TestApplyAdvertiserBlocking(t *testing.T) {
 			want: want{
 				rejectedBidIds: []string{"a.com_bid"},
 				validBidCountPerSeat: map[string]int{
-					"vast_tag_bidder": 1,
+					"vast_tag_bidder": 3,
 				},
 			},
 		},

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -2854,9 +2854,6 @@ func TestApplyAdvertiserBlocking(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.name != "ad_domains_normalized_and_checked" {
-				return
-			}
 			seatBids := make(map[openrtb_ext.BidderName]*pbsOrtbSeatBid)
 			adapterMap := make(map[openrtb_ext.BidderName]adaptedBidder, 0)
 			for adaptor, sbids := range tt.args.adaptorSeatBids {


### PR DESCRIPTION
Filter out Ads based on domains provided in the request

@pm-viral-vala and /  @PubMatic-OpenWrap : Following review comments are addressed

1. Renamed `adjustDomain` to `noarmalizeDomain`
2. normalizeDomain will now check, if the input is publicsuffix (without icann). If it is publicsuffix, error will be returned with empty value
3. Added few more unit tests.


- [ ] Ensure `getAdvertisers` is addressed by OTT-100  before mering this code to master