### PR TITLE
OTT-174: Added bid ID , Ad Unit as tracking parameters and ADomain handling change

### DIFF
--- a/endpoints/events/vtrack_test.go
+++ b/endpoints/events/vtrack_test.go
@@ -941,6 +941,7 @@ func TestGetVideoEventTracking(t *testing.T) {
 					App: &openrtb.App{
 						Bundle: "someappbundle",
 					},
+					Imp: []openrtb.Imp{},
 				},
 			},
 			want: want{
@@ -962,6 +963,7 @@ func TestGetVideoEventTracking(t *testing.T) {
 				bid:        &openrtb.Bid{},
 				req: &openrtb.BidRequest{
 					App: &openrtb.App{}, // no app bundle value
+					Imp: []openrtb.Imp{},
 				},
 			},
 			want: want{
@@ -984,6 +986,7 @@ func TestGetVideoEventTracking(t *testing.T) {
 					App: &openrtb.App{
 						Bundle: "myapp", // do not expect this value
 					},
+					Imp: []openrtb.Imp{},
 					Ext: []byte(`{"prebid":{
 								"macros": {
 									"[DOMAIN]": "my_custom_value"
@@ -1010,6 +1013,7 @@ func TestGetVideoEventTracking(t *testing.T) {
 					App: &openrtb.App{
 						Bundle: "myapp123",
 					},
+					Imp: []openrtb.Imp{},
 				},
 			},
 			want: want{
@@ -1034,6 +1038,7 @@ func TestGetVideoEventTracking(t *testing.T) {
 								"CUSTOM_MACRO": "my_custom_value"
 							}
 					}}`),
+					Imp: []openrtb.Imp{},
 				},
 			},
 			want: want{
@@ -1058,6 +1063,7 @@ func TestGetVideoEventTracking(t *testing.T) {
 								"": "my_custom_value"
 							}
 					}}`),
+					Imp: []openrtb.Imp{},
 				},
 			},
 			want: want{
@@ -1082,6 +1088,7 @@ func TestGetVideoEventTracking(t *testing.T) {
 								"": "my_custom_value"
 							}
 					}}`),
+					Imp: []openrtb.Imp{},
 				},
 			},
 			want: want{
@@ -1098,13 +1105,13 @@ func TestGetVideoEventTracking(t *testing.T) {
 		},
 		{
 			name: "empty_tracker_url",
-			args: args{trackerURL: "    "},
+			args: args{trackerURL: "    ", req: &openrtb.BidRequest{Imp: []openrtb.Imp{}}},
 			want: want{trackerURLMap: make(map[string]string)},
 		},
 		{
 			name: "all_macros", // expect encoding for WRAPPER_IMPRESSION_ID macro
 			args: args{
-				trackerURL: "https://company.tracker.com?operId=8&e=[EVENT_ID]&p=[PBS-ACCOUNT]&pid=[PROFILE_ID]&v=[PROFILE_VERSION]&ts=[UNIX_TIMESTAMP]&pn=[PBS-BIDDER]&advertiser_id=[ADVERTISER_NAME]&sURL=[DOMAIN]&pfi=[PLATFORM]&af=[ADTYPE]&iid=[WRAPPER_IMPRESSION_ID]&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=[AD_UNIT_ID]",
+				trackerURL: "https://company.tracker.com?operId=8&e=[EVENT_ID]&p=[PBS-ACCOUNT]&pid=[PROFILE_ID]&v=[PROFILE_VERSION]&ts=[UNIX_TIMESTAMP]&pn=[PBS-BIDDER]&advertiser_id=[ADVERTISER_NAME]&sURL=[DOMAIN]&pfi=[PLATFORM]&af=[ADTYPE]&iid=[WRAPPER_IMPRESSION_ID]&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=[AD_UNIT_ID]&bidid=[PBS-BIDID]",
 				req: &openrtb.BidRequest{
 					App: &openrtb.App{Bundle: "com.someapp.com", Publisher: &openrtb.Publisher{ID: "5890"}},
 					Ext: []byte(`{
@@ -1122,23 +1129,20 @@ func TestGetVideoEventTracking(t *testing.T) {
 						{TagID: "/testadunit/1", ID: "imp_1"},
 					},
 				},
-				bid:    &openrtb.Bid{ADomain: []string{"a.com", "b.com"}, ImpID: "imp_1"},
+				bid:    &openrtb.Bid{ADomain: []string{"http://a.com/32?k=v", "b.com"}, ImpID: "imp_1", ID: "test_bid_id"},
 				bidder: "test_bidder:234",
 			},
 			want: want{
 				trackerURLMap: map[string]string{
-					"firstQuartile": "https://company.tracker.com?operId=8&e=4&p=5890&pid=100&v=2&ts=1234567890&pn=test_bidder%3A234&advertiser_id=a.com%2Cb.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1",
-					"midpoint":      "https://company.tracker.com?operId=8&e=3&p=5890&pid=100&v=2&ts=1234567890&pn=test_bidder%3A234&advertiser_id=a.com%2Cb.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1",
-					"thirdQuartile": "https://company.tracker.com?operId=8&e=5&p=5890&pid=100&v=2&ts=1234567890&pn=test_bidder%3A234&advertiser_id=a.com%2Cb.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1",
-					"complete":      "https://company.tracker.com?operId=8&e=6&p=5890&pid=100&v=2&ts=1234567890&pn=test_bidder%3A234&advertiser_id=a.com%2Cb.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1"},
+					"firstQuartile": "https://company.tracker.com?operId=8&e=4&p=5890&pid=100&v=2&ts=1234567890&pn=test_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=test_bid_id",
+					"midpoint":      "https://company.tracker.com?operId=8&e=3&p=5890&pid=100&v=2&ts=1234567890&pn=test_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=test_bid_id",
+					"thirdQuartile": "https://company.tracker.com?operId=8&e=5&p=5890&pid=100&v=2&ts=1234567890&pn=test_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=test_bid_id",
+					"complete":      "https://company.tracker.com?operId=8&e=6&p=5890&pid=100&v=2&ts=1234567890&pn=test_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=test_bid_id"},
 			},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if "all_macros" != tc.name {
-				return
-			}
 			if nil == tc.args.bid {
 				tc.args.bid = &openrtb.Bid{}
 			}
@@ -1159,6 +1163,12 @@ func TestGetVideoEventTracking(t *testing.T) {
 					for i := 0; i < len(ev); i++ {
 						assert.Equal(t, ev[i], av[i], fmt.Sprintf("Expected '%v' for '%v'. but found %v", ev[i], k, av[i]))
 					}
+				}
+
+				// error out if extra query params
+				if len(expectedValues) != len(actualValues) {
+					assert.Equal(t, expectedValues, actualValues, fmt.Sprintf("Expected '%v' query params but found '%v'", len(expectedValues), len(actualValues)))
+					break
 				}
 			}
 		})

--- a/endpoints/events/vtrack_test.go
+++ b/endpoints/events/vtrack_test.go
@@ -1104,7 +1104,7 @@ func TestGetVideoEventTracking(t *testing.T) {
 		{
 			name: "all_macros", // expect encoding for WRAPPER_IMPRESSION_ID macro
 			args: args{
-				trackerURL: "https://company.tracker.com?operId=8&e=[EVENT_ID]&p=[PBS-ACCOUNT]&pid=[PROFILE_ID]&v=[PROFILE_VERSION]&ts=[UNIX_TIMESTAMP]&pn=[PBS-BIDDER]&advertiser_id=[ADVERTISER_NAME]&sURL=[DOMAIN]&pfi=[PLATFORM]&af=[ADTYPE]&iid=[WRAPPER_IMPRESSION_ID]&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]",
+				trackerURL: "https://company.tracker.com?operId=8&e=[EVENT_ID]&p=[PBS-ACCOUNT]&pid=[PROFILE_ID]&v=[PROFILE_VERSION]&ts=[UNIX_TIMESTAMP]&pn=[PBS-BIDDER]&advertiser_id=[ADVERTISER_NAME]&sURL=[DOMAIN]&pfi=[PLATFORM]&af=[ADTYPE]&iid=[WRAPPER_IMPRESSION_ID]&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=[AD_UNIT_ID]",
 				req: &openrtb.BidRequest{
 					App: &openrtb.App{Bundle: "com.someapp.com", Publisher: &openrtb.Publisher{ID: "5890"}},
 					Ext: []byte(`{
@@ -1118,25 +1118,38 @@ func TestGetVideoEventTracking(t *testing.T) {
 								}
 						}
 					}`),
+					Imp: []openrtb.Imp{
+						{TagID: "/testadunit/1", ID: "imp_1"},
+					},
 				},
-				bid:    &openrtb.Bid{ADomain: []string{"a.com", "b.com"}},
+				bid:    &openrtb.Bid{ADomain: []string{"a.com", "b.com"}, ImpID: "imp_1"},
 				bidder: "test_bidder:234",
 			},
 			want: want{
 				trackerURLMap: map[string]string{
-					"firstQuartile": "https://company.tracker.com?operId=8&e=4&p=5890&pid=100&v=2&ts=1234567890&pn=test_bidder%3A234&advertiser_id=a.com%2Cb.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]",
-					"midpoint":      "https://company.tracker.com?operId=8&e=3&p=5890&pid=100&v=2&ts=1234567890&pn=test_bidder%3A234&advertiser_id=a.com%2Cb.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]",
-					"thirdQuartile": "https://company.tracker.com?operId=8&e=5&p=5890&pid=100&v=2&ts=1234567890&pn=test_bidder%3A234&advertiser_id=a.com%2Cb.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]",
-					"complete":      "https://company.tracker.com?operId=8&e=6&p=5890&pid=100&v=2&ts=1234567890&pn=test_bidder%3A234&advertiser_id=a.com%2Cb.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]"},
+					"firstQuartile": "https://company.tracker.com?operId=8&e=4&p=5890&pid=100&v=2&ts=1234567890&pn=test_bidder%3A234&advertiser_id=a.com%2Cb.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1",
+					"midpoint":      "https://company.tracker.com?operId=8&e=3&p=5890&pid=100&v=2&ts=1234567890&pn=test_bidder%3A234&advertiser_id=a.com%2Cb.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1",
+					"thirdQuartile": "https://company.tracker.com?operId=8&e=5&p=5890&pid=100&v=2&ts=1234567890&pn=test_bidder%3A234&advertiser_id=a.com%2Cb.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1",
+					"complete":      "https://company.tracker.com?operId=8&e=6&p=5890&pid=100&v=2&ts=1234567890&pn=test_bidder%3A234&advertiser_id=a.com%2Cb.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1"},
 			},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			if "all_macros" != tc.name {
+				return
+			}
 			if nil == tc.args.bid {
 				tc.args.bid = &openrtb.Bid{}
 			}
-			eventURLMap := GetVideoEventTracking(tc.args.trackerURL, tc.args.bid, tc.args.bidder, tc.args.accountId, tc.args.timestamp, tc.args.req, tc.args.doc)
+
+			impMap := map[string]*openrtb.Imp{}
+
+			for _, imp := range tc.args.req.Imp {
+				impMap[imp.ID] = &imp
+			}
+
+			eventURLMap := GetVideoEventTracking(tc.args.trackerURL, tc.args.bid, tc.args.bidder, tc.args.accountId, tc.args.timestamp, tc.args.req, tc.args.doc, impMap)
 
 			for event, eurl := range tc.want.trackerURLMap {
 				expectedValues, _ := url.ParseQuery(eurl)

--- a/endpoints/openrtb2/ctv_auction.go
+++ b/endpoints/openrtb2/ctv_auction.go
@@ -834,10 +834,10 @@ func getAdPodBidCreative(video *openrtb.Video, adpod *types.AdPodBid) *string {
 			adjustBidIDInVideoEventTrackers(adDoc, bid.Bid)
 			adm, err := adDoc.WriteToString()
 			if nil != err {
-				fmt.Printf("ERROR, %v", err.Error())
-				return nil
+				util.JLogf("ERROR, %v", err.Error())
+			} else {
+				bid.AdM = adm
 			}
-			bid.AdM = adm
 
 			vastTag := adDoc.SelectElement(constant.VASTElement)
 

--- a/endpoints/openrtb2/ctv_auction.go
+++ b/endpoints/openrtb2/ctv_auction.go
@@ -931,8 +931,14 @@ func adjustBidIDInVideoEventTrackers(doc *etree.Document, bid *openrtb.Bid) {
 				u, e := url.Parse(trackingEvent.Text())
 				if nil == e {
 					values, e := url.ParseQuery(u.RawQuery)
-					if nil == e {
-						values.Set("bidid", bid.ID)
+					if nil == e && nil != values["bidid"] {
+						// handling collision
+						// if any tracker has same key bidid then prevent it from replacing the value
+						// for this, check following
+						// if current tracker URL's bidid is present in bid.ID (ctv auction generated)
+						if strings.HasSuffix(bid.ID, values["bidid"][0]) {
+							values.Set("bidid", bid.ID)
+						}
 					}
 					u.RawQuery = values.Encode()
 					trackingEvent.SetText(u.String())

--- a/endpoints/openrtb2/ctv_auction.go
+++ b/endpoints/openrtb2/ctv_auction.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	accountService "github.com/PubMatic-OpenWrap/prebid-server/account"
 	"github.com/PubMatic-OpenWrap/prebid-server/analytics"
 	"github.com/PubMatic-OpenWrap/prebid-server/config"
+	"github.com/PubMatic-OpenWrap/prebid-server/endpoints/events"
 	"github.com/PubMatic-OpenWrap/prebid-server/endpoints/openrtb2/ctv/combination"
 	"github.com/PubMatic-OpenWrap/prebid-server/endpoints/openrtb2/ctv/constant"
 	"github.com/PubMatic-OpenWrap/prebid-server/endpoints/openrtb2/ctv/impressions"
@@ -828,6 +830,15 @@ func getAdPodBidCreative(video *openrtb.Video, adpod *types.AdPodBid) *string {
 				continue
 			}
 
+			// adjust bidid in video event trackers and update
+			adjustBidIDInVideoEventTrackers(adDoc, bid.Bid)
+			adm, err := adDoc.WriteToString()
+			if nil != err {
+				fmt.Printf("ERROR, %v", err.Error())
+				return nil
+			}
+			bid.AdM = adm
+
 			vastTag := adDoc.SelectElement(constant.VASTElement)
 
 			//Get Actual VAST Version
@@ -853,6 +864,7 @@ func getAdPodBidCreative(video *openrtb.Video, adpod *types.AdPodBid) *string {
 	}
 
 	vast.CreateAttr(constant.VASTVersionAttribute, constant.VASTVersionsStr[int(version)])
+
 	bidAdM, err := doc.WriteToString()
 	if nil != err {
 		fmt.Printf("ERROR, %v", err.Error())
@@ -906,4 +918,26 @@ func addTargetingKey(bid *openrtb.Bid, key openrtb_ext.TargetingKey, value strin
 		bid.Ext = raw
 	}
 	return err
+}
+
+func adjustBidIDInVideoEventTrackers(doc *etree.Document, bid *openrtb.Bid) {
+	// adjusment: update bid.id with ctv module generated bid.id
+	creatives := events.FindCreatives(doc)
+	for _, creative := range creatives {
+		trackingEvents := creative.FindElements("TrackingEvents/Tracking")
+		if nil != trackingEvents {
+			// update bidid= value with ctv generated bid id for this bid
+			for _, trackingEvent := range trackingEvents {
+				u, e := url.Parse(trackingEvent.Text())
+				if nil == e {
+					values, e := url.ParseQuery(u.RawQuery)
+					if nil == e {
+						values.Set("bidid", bid.ID)
+					}
+					u.RawQuery = values.Encode()
+					trackingEvent.SetText(u.String())
+				}
+			}
+		}
+	}
 }

--- a/endpoints/openrtb2/ctv_auction_test.go
+++ b/endpoints/openrtb2/ctv_auction_test.go
@@ -2,8 +2,11 @@ package openrtb2
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/url"
 	"testing"
 
+	"github.com/PubMatic-OpenWrap/etree"
 	"github.com/PubMatic-OpenWrap/openrtb"
 	"github.com/PubMatic-OpenWrap/prebid-server/openrtb_ext"
 	"github.com/stretchr/testify/assert"
@@ -55,4 +58,86 @@ func TestAddTargetingKeys(t *testing.T) {
 		})
 	}
 	assert.Equal(t, "Invalid bid", addTargetingKey(nil, openrtb_ext.HbCategoryDurationKey, "some value").Error())
+}
+
+func TestAdjustBidIDInVideoEventTrackers(t *testing.T) {
+	type args struct {
+		modifiedBid *openrtb.Bid
+	}
+	type want struct {
+		eventURLMap map[string]string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "replace_with_custom_ctv_bid_id",
+			want: want{
+				eventURLMap: map[string]string{
+					"thirdQuartile": "https://thirdQuartile.com?key1=value1&bidid=ctv_bid_123",
+					"complete":      "https://complete.com?key1=value1&bidid=ctv_bid_123&key2=value2",
+					"firstQuartile": "https://firstQuartile.com?key1=value1&bidid=ctv_bid_123&key2=value2",
+					"midpoint":      "https://midpoint.com?key1=value1&bidid=ctv_bid_123&key2=value2",
+				},
+			},
+			args: args{
+				modifiedBid: &openrtb.Bid{
+					ID: "ctv_bid_123",
+					AdM: `<VAST  version="3.0">
+					<Ad>
+						<Wrapper>
+							<AdSystem>
+								<![CDATA[prebid.org wrapper]]>
+							</AdSystem>
+							<VASTAdTagURI>
+								<![CDATA[https://search.spotxchange.com/vast/2.00/85394?VPI=MP4]]>
+							</VASTAdTagURI>
+							<Impression>
+								<![CDATA[https://imptracker.url]]>
+							</Impression>
+							<Impression/>
+							<Creatives>
+								<Creative>
+									<Linear>
+										<TrackingEvents>
+											<Tracking  event="thirdQuartile"><![CDATA[https://thirdQuartile.com?key1=value1&bidid=ctv_bid_123]]></Tracking>
+											<Tracking  event="complete"><![CDATA[https://complete.com?key1=value1&bidid=ctv_bid_123&key2=value2]]></Tracking>
+											<Tracking  event="firstQuartile"><![CDATA[https://firstQuartile.com?key1=value1&bidid=ctv_bid_123&key2=value2]]></Tracking>
+											<Tracking  event="midpoint"><![CDATA[https://midpoint.com?key1=value1&bidid=ctv_bid_123&key2=value2]]></Tracking>
+										</TrackingEvents>
+									</Linear>
+								</Creative>
+							</Creatives>
+							<Error>
+								<![CDATA[https://error.com]]>
+							</Error>
+						</Wrapper>
+					</Ad>
+				</VAST>`,
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		doc := etree.NewDocument()
+		doc.ReadFromString(test.args.modifiedBid.AdM)
+		adjustBidIDInVideoEventTrackers(doc, test.args.modifiedBid)
+		events := doc.FindElements("VAST/Ad/Wrapper/Creatives/Creative/Linear/TrackingEvents/Tracking")
+		for _, event := range events {
+			evntName := event.SelectAttr("event").Value
+			expectedURL, _ := url.Parse(test.want.eventURLMap[evntName])
+			expectedValues := expectedURL.Query()
+			actualURL, _ := url.Parse(event.Text())
+			actualValues := actualURL.Query()
+			for k, ev := range expectedValues {
+				av := actualValues[k]
+				for i := 0; i < len(ev); i++ {
+					assert.Equal(t, ev[i], av[i], fmt.Sprintf("Expected '%v' for '%v'. but found %v", ev[i], k, av[i]))
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
@pm-viral-vala : please review and approve.
1. Add **au** parameter in OpenWrap video event tracker URL 
2. **au** parameter will log the Publisher's Ad Tag Id (using imp.tagId) from the respective impression object.
3. Only for Video Creative(for any endpoint in OW).
4. Add **bidid** parameter in OpenWrap video event tracker URL. this parameter will contain value present in bid.ID field
5. **NOTE**:  In the case of CTV/Ad Pod response, **bidid** value would be id generated by CTV auction module. Hence, it may not be the same as bid.ID
6. **advertiser_id** : Pass only index 0 value from bid.ADomain array. Instead of sending all array values.
7. **advertiser_id**: Ensure that only the domain is getting passed as a part of this parameter. For example, if bid.ADomain = ["http://abc.com:3000/pqr?k=v" ] then *advertiser_id=*abc.com