### PR TITLE
OTT-172: Set default min ads to 1 from 2

### DIFF
--- a/openrtb_ext/adpod.go
+++ b/openrtb_ext/adpod.go
@@ -184,7 +184,7 @@ func (ext *ExtVideoAdPod) Validate() (err []error) {
 func (pod *VideoAdPod) SetDefaultValue() {
 	//pod.MinAds setting default value
 	if nil == pod.MinAds {
-		pod.MinAds = getIntPtr(2)
+		pod.MinAds = getIntPtr(1) //OTT-172	 Setting the default minimum ads to 1
 	}
 
 	//pod.MaxAds setting default value


### PR DESCRIPTION
Changed the default minimum AdSlot value from 2 to 1 to get a better fill rate.