### PR TITLE
UOE-7051: Fix pubmatic aliases buyid targeting key

### DIFF
--- a/adapters/bidder.go
+++ b/adapters/bidder.go
@@ -125,6 +125,8 @@ type RequestData struct {
 	Uri     string
 	Body    []byte
 	Headers http.Header
+
+	BidderName openrtb_ext.BidderName `json:"-"`
 }
 
 // ExtImpBidder can be used by Bidders to unmarshal any request.imp[i].ext.

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -22,7 +22,7 @@ const MAX_IMPRESSIONS_PUBMATIC = 30
 const (
 	PUBMATIC            = "[PUBMATIC]"
 	buyId               = "buyid"
-	buyIdTargetingKey   = "hb_buyid_pubmatic"
+	buyIdTargetingKey   = "hb_buyid_"
 	skAdnetworkKey      = "skadn"
 	rewardKey           = "reward"
 	dctrKeywordName     = "dctr"
@@ -463,7 +463,7 @@ func (a *PubmaticAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externa
 
 	var errs []error
 	for _, sb := range bidResp.SeatBid {
-		targets := getTargetingKeys(sb.Ext)
+		targets := getTargetingKeys(sb.Ext, string(externalRequest.BidderName))
 		for i := 0; i < len(sb.Bid); i++ {
 			bid := sb.Bid[i]
 			// Copy SeatBid Ext to Bid.Ext
@@ -529,13 +529,13 @@ func Builder(bidderName openrtb_ext.BidderName, config config.Adapter) (adapters
 	return bidder, nil
 }
 
-func getTargetingKeys(bidExt json.RawMessage) map[string]string {
+func getTargetingKeys(bidExt json.RawMessage, bidderName string) map[string]string {
 	targets := map[string]string{}
 	if bidExt != nil {
 		bidExtMap := make(map[string]interface{})
 		err := json.Unmarshal(bidExt, &bidExtMap)
 		if err == nil && bidExtMap[buyId] != nil {
-			targets[buyIdTargetingKey] = string(bidExtMap[buyId].(string))
+			targets[buyIdTargetingKey+bidderName] = string(bidExtMap[buyId].(string))
 		}
 	}
 	return targets

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -71,7 +71,7 @@ func TestGetBidTypeForUnsupportedCode(t *testing.T) {
 
 func TestGetAdServerTargetingForEmptyExt(t *testing.T) {
 	ext := json.RawMessage(`{}`)
-	targets := getTargetingKeys(ext)
+	targets := getTargetingKeys(ext, "pubmatic")
 	// banner is the default bid type when no bidType key is present in the bid.ext
 	if targets != nil && targets["hb_buyid_pubmatic"] != "" {
 		t.Errorf("It should not contained AdserverTageting")
@@ -80,13 +80,27 @@ func TestGetAdServerTargetingForEmptyExt(t *testing.T) {
 
 func TestGetAdServerTargetingForValidExt(t *testing.T) {
 	ext := json.RawMessage("{\"buyid\":\"testBuyId\"}")
-	targets := getTargetingKeys(ext)
+	targets := getTargetingKeys(ext, "pubmatic")
 	// banner is the default bid type when no bidType key is present in the bid.ext
 	if targets == nil {
 		t.Error("It should have targets")
 		t.FailNow()
 	}
 	if targets != nil && targets["hb_buyid_pubmatic"] != "testBuyId" {
+		t.Error("It should have testBuyId as targeting")
+		t.FailNow()
+	}
+}
+
+func TestGetAdServerTargetingForPubmaticAlias(t *testing.T) {
+	ext := json.RawMessage("{\"buyid\":\"testBuyId-alias\"}")
+	targets := getTargetingKeys(ext, "dummy-alias")
+	// banner is the default bid type when no bidType key is present in the bid.ext
+	if targets == nil {
+		t.Error("It should have targets")
+		t.FailNow()
+	}
+	if targets != nil && targets["hb_buyid_dummy-alias"] != "testBuyId-alias" {
 		t.Error("It should have testBuyId as targeting")
 		t.FailNow()
 	}

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -202,6 +202,7 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, request *openrtb2.B
 		}
 
 		if httpInfo.err == nil {
+			httpInfo.request.BidderName = name
 			bidResponse, moreErrs := bidder.Bidder.MakeBids(request, httpInfo.request, httpInfo.response)
 			errs = append(errs, moreErrs...)
 


### PR DESCRIPTION
(cherry picked from https://github.com/PubMatic-OpenWrap/prebid-server/pull/259)

# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [x] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [x] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
