### PR TITLE
OTT-311: Updated for using generated bid Id from prebid server

### DIFF
--- a/endpoints/events/vtrack_ow_test.go
+++ b/endpoints/events/vtrack_ow_test.go
@@ -13,6 +13,7 @@ import (
 func TestInjectVideoEventTrackers(t *testing.T) {
 	type args struct {
 		externalURL string
+		genbidID    string
 		bid         *openrtb2.Bid
 		req         *openrtb2.BidRequest
 	}
@@ -185,7 +186,7 @@ func TestInjectVideoEventTrackers(t *testing.T) {
 			timestamp := int64(0)
 			requestingBidder := "test_bidder"
 			bidderCoreName := "test_core_bidder"
-			injectedVast, injected, ierr := InjectVideoEventTrackers(tc.args.externalURL, vast, tc.args.bid, requestingBidder, bidderCoreName, accountID, timestamp, tc.args.req)
+			injectedVast, injected, ierr := InjectVideoEventTrackers(tc.args.externalURL, vast, tc.args.bid, tc.args.genbidID, requestingBidder, bidderCoreName, accountID, timestamp, tc.args.req)
 
 			if !injected {
 				// expect no change in input vast if tracking events are not injected
@@ -231,11 +232,13 @@ func TestInjectVideoEventTrackers(t *testing.T) {
 	}
 }
 
+
 func TestGetVideoEventTracking(t *testing.T) {
 	type args struct {
 		trackerURL       string
 		bid              *openrtb2.Bid
 		requestingBidder string
+		gen_bidid        string
 		bidderCoreName   string
 		accountId        string
 		timestamp        int64
@@ -464,9 +467,9 @@ func TestGetVideoEventTracking(t *testing.T) {
 			},
 		},
 		{
-			name: "all_macros", // expect encoding for WRAPPER_IMPRESSION_ID macro
+			name: "all_macros with generated_bidId", // expect encoding for WRAPPER_IMPRESSION_ID macro
 			args: args{
-				trackerURL: "https://company.tracker.com?operId=8&e=[EVENT_ID]&p=[PBS-ACCOUNT]&pid=[PROFILE_ID]&v=[PROFILE_VERSION]&ts=[UNIX_TIMESTAMP]&pn=[PBS-BIDDER]&advertiser_id=[ADVERTISER_NAME]&sURL=[DOMAIN]&pfi=[PLATFORM]&af=[ADTYPE]&iid=[WRAPPER_IMPRESSION_ID]&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=[AD_UNIT]&bidid=[PBS-BIDID]&bc=[BIDDER_CODE]",
+				trackerURL: "https://company.tracker.com?operId=8&e=[EVENT_ID]&p=[PBS-ACCOUNT]&pid=[PROFILE_ID]&v=[PROFILE_VERSION]&ts=[UNIX_TIMESTAMP]&pn=[PBS-BIDDER]&advertiser_id=[ADVERTISER_NAME]&sURL=[DOMAIN]&pfi=[PLATFORM]&af=[ADTYPE]&iid=[WRAPPER_IMPRESSION_ID]&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=[AD_UNIT]&bidid=[PBS-BIDID]&origbidid=[PBS-ORIG_BIDID]&bc=[BIDDER_CODE]",
 				req: &openrtb2.BidRequest{
 					App: &openrtb2.App{Bundle: "com.someapp.com", Publisher: &openrtb2.Publisher{ID: "5890"}},
 					Ext: []byte(`{
@@ -485,16 +488,52 @@ func TestGetVideoEventTracking(t *testing.T) {
 					},
 				},
 				bid:              &openrtb2.Bid{ADomain: []string{"http://a.com/32?k=v", "b.com"}, ImpID: "imp_1", ID: "test_bid_id"},
+				gen_bidid:        "random_bid_id",
 				requestingBidder: "test_bidder:234",
 				bidderCoreName:   "test_core_bidder:234",
 			},
 			want: want{
 				trackerURLMap: map[string]string{
-					"firstQuartile": "https://company.tracker.com?operId=8&e=4&p=5890&pid=100&v=2&ts=1234567890&pn=test_core_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=test_bid_id&bc=test_bidder%3A234",
-					"midpoint":      "https://company.tracker.com?operId=8&e=3&p=5890&pid=100&v=2&ts=1234567890&pn=test_core_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=test_bid_id&bc=test_bidder%3A234",
-					"thirdQuartile": "https://company.tracker.com?operId=8&e=5&p=5890&pid=100&v=2&ts=1234567890&pn=test_core_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=test_bid_id&bc=test_bidder%3A234",
-					"complete":      "https://company.tracker.com?operId=8&e=6&p=5890&pid=100&v=2&ts=1234567890&pn=test_core_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=test_bid_id&bc=test_bidder%3A234",
-					"start":         "https://company.tracker.com?operId=8&e=2&p=5890&pid=100&v=2&ts=1234567890&pn=test_core_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=test_bid_id&bc=test_bidder%3A234"},
+					"firstQuartile": "https://company.tracker.com?operId=8&e=4&p=5890&pid=100&v=2&ts=1234567890&pn=test_core_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=random_bid_id&origbidid=test_bid_id&bc=test_bidder%3A234",
+					"midpoint":      "https://company.tracker.com?operId=8&e=3&p=5890&pid=100&v=2&ts=1234567890&pn=test_core_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=random_bid_id&origbidid=test_bid_id&bc=test_bidder%3A234",
+					"thirdQuartile": "https://company.tracker.com?operId=8&e=5&p=5890&pid=100&v=2&ts=1234567890&pn=test_core_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=random_bid_id&origbidid=test_bid_id&bc=test_bidder%3A234",
+					"complete":      "https://company.tracker.com?operId=8&e=6&p=5890&pid=100&v=2&ts=1234567890&pn=test_core_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=random_bid_id&origbidid=test_bid_id&bc=test_bidder%3A234",
+					"start":         "https://company.tracker.com?operId=8&e=2&p=5890&pid=100&v=2&ts=1234567890&pn=test_core_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=random_bid_id&origbidid=test_bid_id&bc=test_bidder%3A234"},
+			},
+		},
+		{
+			name: "all_macros with empty generated_bidId", // expect encoding for WRAPPER_IMPRESSION_ID macro
+			args: args{
+				trackerURL: "https://company.tracker.com?operId=8&e=[EVENT_ID]&p=[PBS-ACCOUNT]&pid=[PROFILE_ID]&v=[PROFILE_VERSION]&ts=[UNIX_TIMESTAMP]&pn=[PBS-BIDDER]&advertiser_id=[ADVERTISER_NAME]&sURL=[DOMAIN]&pfi=[PLATFORM]&af=[ADTYPE]&iid=[WRAPPER_IMPRESSION_ID]&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=[AD_UNIT]&bidid=[PBS-BIDID]&origbidid=[PBS-ORIG_BIDID]&bc=[BIDDER_CODE]",
+				req: &openrtb2.BidRequest{
+					App: &openrtb2.App{Bundle: "com.someapp.com", Publisher: &openrtb2.Publisher{ID: "5890"}},
+					Ext: []byte(`{
+						"prebid": {
+								"macros": {
+									"[PROFILE_ID]": "100",
+									"[PROFILE_VERSION]": "2",
+									"[UNIX_TIMESTAMP]": "1234567890",
+									"[PLATFORM]": "7",
+									"[WRAPPER_IMPRESSION_ID]": "abc~!@#$%^&&*()_+{}|:\"<>?[]\\;',./"
+								}
+						}
+					}`),
+					Imp: []openrtb2.Imp{
+						{TagID: "/testadunit/1", ID: "imp_1"},
+					},
+				},
+				bid:              &openrtb2.Bid{ADomain: []string{"http://a.com/32?k=v", "b.com"}, ImpID: "imp_1", ID: "test_bid_id"},
+				gen_bidid:        "",
+				requestingBidder: "test_bidder:234",
+				bidderCoreName:   "test_core_bidder:234",
+			},
+			want: want{
+				trackerURLMap: map[string]string{
+					"firstQuartile": "https://company.tracker.com?operId=8&e=4&p=5890&pid=100&v=2&ts=1234567890&pn=test_core_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=test_bid_id&origbidid=test_bid_id&bc=test_bidder%3A234",
+					"midpoint":      "https://company.tracker.com?operId=8&e=3&p=5890&pid=100&v=2&ts=1234567890&pn=test_core_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=test_bid_id&origbidid=test_bid_id&bc=test_bidder%3A234",
+					"thirdQuartile": "https://company.tracker.com?operId=8&e=5&p=5890&pid=100&v=2&ts=1234567890&pn=test_core_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=test_bid_id&origbidid=test_bid_id&bc=test_bidder%3A234",
+					"complete":      "https://company.tracker.com?operId=8&e=6&p=5890&pid=100&v=2&ts=1234567890&pn=test_core_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=test_bid_id&origbidid=test_bid_id&bc=test_bidder%3A234",
+					"start":         "https://company.tracker.com?operId=8&e=2&p=5890&pid=100&v=2&ts=1234567890&pn=test_core_bidder%3A234&advertiser_id=a.com&sURL=com.someapp.com&pfi=7&af=video&iid=abc~%21%40%23%24%25%5E%26%26%2A%28%29_%2B%7B%7D%7C%3A%22%3C%3E%3F%5B%5D%5C%3B%27%2C.%2F&pseq=[PODSEQUENCE]&adcnt=[ADCOUNT]&cb=[CACHEBUSTING]&au=%2Ftestadunit%2F1&bidid=test_bid_id&origbidid=test_bid_id&bc=test_bidder%3A234"},
 			},
 		},
 	}
@@ -511,7 +550,7 @@ func TestGetVideoEventTracking(t *testing.T) {
 				impMap[imp.ID] = &imp
 			}
 
-			eventURLMap := GetVideoEventTracking(tc.args.trackerURL, tc.args.bid, tc.args.requestingBidder, tc.args.bidderCoreName, tc.args.accountId, tc.args.timestamp, tc.args.req, tc.args.doc, impMap)
+			eventURLMap := GetVideoEventTracking(tc.args.trackerURL, tc.args.bid, tc.args.gen_bidid, tc.args.requestingBidder, tc.args.bidderCoreName, tc.args.accountId, tc.args.timestamp, tc.args.req, tc.args.doc, impMap)
 
 			for event, eurl := range tc.want.trackerURLMap {
 
@@ -573,7 +612,6 @@ func TestReplaceMacro(t *testing.T) {
 	}
 
 }
-
 func TestExtractDomain(t *testing.T) {
 	testCases := []struct {
 		description    string

--- a/endpoints/events/vtrack_test.go
+++ b/endpoints/events/vtrack_test.go
@@ -692,7 +692,6 @@ func getVTrackRequestData(wi bool, wic bool) (db []byte, e error) {
 
 	return data.Bytes(), e
 }
-
 func TestGetIntegrationType(t *testing.T) {
 	testCases := []struct {
 		description             string

--- a/endpoints/openrtb2/ctv/types/adpod_types.go
+++ b/endpoints/openrtb2/ctv/types/adpod_types.go
@@ -9,6 +9,7 @@ import (
 //Bid openrtb bid object with extra parameters
 type Bid struct {
 	*openrtb2.Bid
+	openrtb_ext.ExtBid
 	Duration          int
 	Status            constant.BidStatus
 	DealTierSatisfied bool

--- a/endpoints/openrtb2/ctv_auction_test.go
+++ b/endpoints/openrtb2/ctv_auction_test.go
@@ -2,12 +2,8 @@ package openrtb2
 
 import (
 	"encoding/json"
-	"fmt"
-	"net/url"
-	"strings"
 	"testing"
 
-	"github.com/beevik/etree"
 	"github.com/mxmCherry/openrtb/v15/openrtb2"
 	"github.com/prebid/prebid-server/endpoints/openrtb2/ctv/constant"
 	"github.com/prebid/prebid-server/endpoints/openrtb2/ctv/types"
@@ -38,95 +34,6 @@ func TestAddTargetingKeys(t *testing.T) {
 		})
 	}
 	assert.Equal(t, "Invalid bid", addTargetingKey(nil, openrtb_ext.HbCategoryDurationKey, "some value").Error())
-}
-
-func TestAdjustBidIDInVideoEventTrackers(t *testing.T) {
-	type args struct {
-		modifiedBid *openrtb2.Bid
-	}
-	type want struct {
-		eventURLMap map[string]string
-	}
-
-	tests := []struct {
-		name string
-		args args
-		want want
-	}{
-		{
-			name: "replace_with_custom_ctv_bid_id",
-			want: want{
-				eventURLMap: map[string]string{
-					"thirdQuartile": "https://thirdQuartile.com?operId=8&key1=value1&bidid=1-bid_123",
-					"complete":      "https://complete.com?operId=8&key1=value1&bidid=1-bid_123&key2=value2",
-					"firstQuartile": "https://firstQuartile.com?operId=8&key1=value1&bidid=1-bid_123&key2=value2",
-					"midpoint":      "https://midpoint.com?operId=8&key1=value1&bidid=1-bid_123&key2=value2",
-					"someevent":     "https://othermacros?bidid=bid_123&abc=pqr",
-				},
-			},
-			args: args{
-				modifiedBid: &openrtb2.Bid{
-					ID: "1-bid_123",
-					AdM: `<VAST  version="3.0">
-					<Ad>
-						<Wrapper>
-							<AdSystem>
-								<![CDATA[prebid.org wrapper]]>
-							</AdSystem>
-							<VASTAdTagURI>
-								<![CDATA[https://search.spotxchange.com/vast/2.00/85394?VPI=MP4]]>
-							</VASTAdTagURI>
-							<Impression>
-								<![CDATA[https://imptracker.url]]>
-							</Impression>
-							<Impression/>
-							<Creatives>
-								<Creative>
-									<Linear>
-										<TrackingEvents>
-											<Tracking  event="someevent"><![CDATA[https://othermacros?bidid=bid_123&abc=pqr]]></Tracking>
-											<Tracking  event="thirdQuartile"><![CDATA[https://thirdQuartile.com?operId=8&key1=value1&bidid=bid_123]]></Tracking>
-											<Tracking  event="complete"><![CDATA[https://complete.com?operId=8&key1=value1&bidid=bid_123&key2=value2]]></Tracking>
-											<Tracking  event="firstQuartile"><![CDATA[https://firstQuartile.com?operId=8&key1=value1&bidid=bid_123&key2=value2]]></Tracking>
-											<Tracking  event="midpoint"><![CDATA[https://midpoint.com?operId=8&key1=value1&bidid=bid_123&key2=value2]]></Tracking>
-										</TrackingEvents>
-									</Linear>
-								</Creative>
-							</Creatives>
-							<Error>
-								<![CDATA[https://error.com]]>
-							</Error>
-						</Wrapper>
-					</Ad>
-				</VAST>`,
-				},
-			},
-		},
-	}
-	for _, test := range tests {
-		doc := etree.NewDocument()
-		doc.ReadFromString(test.args.modifiedBid.AdM)
-		adjustBidIDInVideoEventTrackers(doc, test.args.modifiedBid)
-		events := doc.FindElements("VAST/Ad/Wrapper/Creatives/Creative/Linear/TrackingEvents/Tracking")
-		for _, event := range events {
-			evntName := event.SelectAttr("event").Value
-			expectedURL, _ := url.Parse(test.want.eventURLMap[evntName])
-			expectedValues := expectedURL.Query()
-			actualURL, _ := url.Parse(event.Text())
-			actualValues := actualURL.Query()
-			for k, ev := range expectedValues {
-				av := actualValues[k]
-				for i := 0; i < len(ev); i++ {
-					assert.Equal(t, ev[i], av[i], fmt.Sprintf("Expected '%v' for '%v' [Event = %v]. but found %v", ev[i], k, evntName, av[i]))
-				}
-			}
-
-			// check if operId=8 is first param
-			if evntName != "someevent" {
-				assert.True(t, strings.HasPrefix(actualURL.RawQuery, "operId=8"), "operId=8 must be first query param")
-			}
-		}
-	}
 }
 
 func TestFilterImpsVastTagsByDuration(t *testing.T) {

--- a/exchange/events.go
+++ b/exchange/events.go
@@ -71,7 +71,7 @@ func (ev *eventTracking) modifyBidVAST(pbsBid *pbsOrtbBid, bidderName openrtb_ex
 	}
 
 	// always inject event  trackers without checkign isModifyingVASTXMLAllowed
-	if newVastXML, injected, _ := events.InjectVideoEventTrackers(trackerURL, vastXML, bid, bidderName.String(), bidderCoreName.String(), ev.accountID, ev.auctionTimestampMs, req); injected {
+	if newVastXML, injected, _ := events.InjectVideoEventTrackers(trackerURL, vastXML, bid, bidID, bidderName.String(), bidderCoreName.String(), ev.accountID, ev.auctionTimestampMs, req); injected {
 		bid.AdM = string(newVastXML)
 	}
 }

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -308,6 +308,7 @@ func (e *exchange) HoldAuction(ctx context.Context, r AuctionRequest, debugLog *
 			for _, seatBid := range adapterBids {
 				for _, pbsBid := range seatBid.bids {
 					pbsBid.generatedBidID, err = e.bidIDGenerator.New()
+					glog.Infof("Original BidID = %s Generated BidID = %s", pbsBid.bid.ID, pbsBid.generatedBidID)
 					if err != nil {
 						errs = append(errs, errors.New("Error generating bid.ext.prebid.bidid"))
 					}


### PR DESCRIPTION
# Description

OTT-311: Changes for using generated bid ID into tracker and logger

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
