### PR TITLE
OTT-356: Setting WB=1 for adpod bids for new generate bid id feature

### DIFF
--- a/endpoints/events/vtrack_ow_test.go
+++ b/endpoints/events/vtrack_ow_test.go
@@ -232,7 +232,6 @@ func TestInjectVideoEventTrackers(t *testing.T) {
 	}
 }
 
-
 func TestGetVideoEventTracking(t *testing.T) {
 	type args struct {
 		trackerURL       string

--- a/endpoints/openrtb2/ctv_auction.go
+++ b/endpoints/openrtb2/ctv_auction.go
@@ -746,6 +746,7 @@ func (deps *ctvEndpointDeps) getBids(resp *openrtb2.BidResponse) {
 
 				impBids.Bids = append(impBids.Bids, &types.Bid{
 					Bid:               bid,
+					ExtBid:            ext,
 					Status:            status,
 					Duration:          int(duration),
 					DealTierSatisfied: util.GetDealTierSatisfied(&ext),
@@ -1044,8 +1045,14 @@ func getAdPodBidExtension(adpod *types.AdPodBid) json.RawMessage {
 	}
 
 	for i, bid := range adpod.Bids {
+		//get unique bid id
+		bidID := bid.ID
+		if bid.ExtBid.Prebid != nil && bid.ExtBid.Prebid.BidId != "" {
+			bidID = bid.ExtBid.Prebid.BidId
+		}
+
 		//adding bid id in adpod.refbids
-		bidExt.AdPod.RefBids[i] = bid.ID
+		bidExt.AdPod.RefBids[i] = bidID
 
 		//updating exact duration of adpod creative
 		bidExt.Prebid.Video.Duration += int(bid.Duration)

--- a/floors/enforce.go
+++ b/floors/enforce.go
@@ -6,7 +6,7 @@ import (
 
 func ShouldEnforceFloors(requestExt *openrtb_ext.PriceFloorRules, configEnforceRate int, f func(int) int) bool {
 
-	if *requestExt.Skipped {
+	if requestExt != nil && requestExt.Skipped != nil && *requestExt.Skipped {
 		return false
 	}
 


### PR DESCRIPTION
# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [x] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [x] JIRA number is added in the PR title and the commit message.
- [x] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
