### PR TITLE
OTT-478: Added updatedrequest in debug log response to know about floor rule selection 

### DIFF
--- a/floors/enforce.go
+++ b/floors/enforce.go
@@ -10,6 +10,10 @@ func ShouldEnforceFloors(requestExt *openrtb_ext.PriceFloorRules, configEnforceR
 		return false
 	}
 
+	if requestExt.Enforcement != nil && !requestExt.Enforcement.EnforcePBS {
+		return requestExt.Enforcement.EnforcePBS
+	}
+
 	if requestExt.Enforcement != nil && requestExt.Enforcement.EnforceRate > 0 {
 		configEnforceRate = requestExt.Enforcement.EnforceRate
 	}

--- a/openrtb_ext/response.go
+++ b/openrtb_ext/response.go
@@ -28,6 +28,8 @@ type ExtResponseDebug struct {
 	HttpCalls map[BidderName][]*ExtHttpCall `json:"httpcalls,omitempty"`
 	// Request after resolution of stored requests and debug overrides
 	ResolvedRequest json.RawMessage `json:"resolvedrequest,omitempty"`
+	// Request after flors signalling
+	UpdatedRequest json.RawMessage `json:"updatedrequest,omitempty"`
 }
 
 // ExtResponseSyncData defines the contract for bidresponse.ext.usersync.{bidder}


### PR DESCRIPTION
To know about floor rule selection and imp.bidfloor value, Updatedrequest field is added into debug response when debug=1 and floors are enabled in request.

# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [x] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [x] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
