### PR TITLE
UOE-7958: Added Data field in ExtUser

### DIFF
--- a/openrtb_ext/user.go
+++ b/openrtb_ext/user.go
@@ -11,6 +11,8 @@ type ExtUser struct {
 	Prebid *ExtUserPrebid `json:"prebid,omitempty"`
 
 	Eids []ExtUserEid `json:"eids,omitempty"`
+
+	Data json.RawMessage `json:"data,omitempty"`
 }
 
 // ExtUserPrebid defines the contract for bidrequest.user.ext.prebid


### PR DESCRIPTION
#  Added Data field in ExtUser

One of our Bidder Partner needed req.user.ext.data to pass user related information, adding Data field enables to pass the data regarding user with UserExt object format

# Checklist:

- [x] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [x] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
