### PR TITLE
OTT-737: Enforce floors when req.ext.prebid not provided, but imp.bidfloor provided

### DIFF
--- a/exchange/floors_test.go
+++ b/exchange/floors_test.go
@@ -1164,6 +1164,146 @@ func TestEnforceFloors(t *testing.T) {
 			want1: []string{"bid rejected [bid ID: some-bid-11] reason: bid price value 0.5000 USD is less than bidFloor value 20.0100 USD for impression id some-impression-id-1 bidder appnexus"},
 		},
 		{
+			name: "Should enforce floors when imp.bidfloor provided and req.ext.prebid not provided",
+			args: args{
+				r: func() *AuctionRequest {
+					var wrapper openrtb_ext.RequestWrapper
+					strReq := `{"id":"95d6643c-3da6-40a2-b9ca-12279393ffbf","imp":[{"id":"some-impression-id-1","banner":{"format":[{"w":300,"h":250}],"pos":7,"api":[5,6,7]},"displaymanager":"PubMatic_OpenBid_SDK","displaymanagerver":"1.4.0","instl":1,"tagid":"/43743431/DMDemo","bidfloor":5.01,"bidfloorcur":"USD","secure":0,"ext":{"appnexus-1":{"placementId":234234},"appnexus-2":{"placementId":9880618},"pubmatic":{"adSlot":"/43743431/DMDemo@300x250","publisherId":"5890","wiid":"42faaac0-9134-41c2-a283-77f1302d00ac","wrapper":{"version":1,"profile":7255}},"prebid":{"floors":{"floorRule":"banner|300x250|www.website1.com","floorRuleValue":20.01}}}}],"app":{"name":"OpenWrapperSample","bundle":"com.pubmatic.openbid.app","domain":"www.website1.com","storeurl":"https://itunes.apple.com/us/app/pubmatic-sdk-app/id1175273098?appnexus_banner_fixedbid=1&fixedbid=1","ver":"1.0","publisher":{"id":"5890"}},"device":{"ua":"Mozilla/5.0 (Linux; Android 9; Android SDK built for x86 Build/PSR1.180720.075; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36","geo":{"lat":37.421998333333335,"lon":-122.08400000000002,"type":1},"lmt":0,"ip":"192.0.2.1","devicetype":4,"make":"Google","model":"Android SDK built for x86","os":"Android","osv":"9","h":1794,"w":1080,"pxratio":2.625,"js":1,"language":"en","carrier":"Android","mccmnc":"310-260","connectiontype":6,"ifa":"07c387f2-e030-428f-8336-42f682150759"},"user":{},"at":1,"tmax":1891525,"cur":["USD"],"source":{"tid":"95d6643c-3da6-40a2-b9ca-12279393ffbf","ext":{"omidpn":"PubMatic","omidpv":"1.2.11-Pubmatic"}},"ext":{}}`
+					_ = json.Unmarshal([]byte(strReq), &wrapper)
+					ar := AuctionRequest{BidRequestWrapper: &wrapper}
+					return &ar
+				}(),
+				seatBids: map[openrtb_ext.BidderName]*pbsOrtbSeatBid{
+					"pubmatic": {
+						bids: []*pbsOrtbBid{
+							{
+								bid: &openrtb2.Bid{
+									ID:     "some-bid-1",
+									Price:  1.2,
+									ImpID:  "some-impression-id-1",
+									DealID: "1",
+								},
+							},
+						},
+						currency: "USD",
+					},
+					"appnexus": {
+						bids: []*pbsOrtbBid{
+							{
+								bid: &openrtb2.Bid{
+									ID:    "some-bid-11",
+									Price: 0.5,
+									ImpID: "some-impression-id-1",
+								},
+							},
+						},
+						currency: "USD",
+					},
+				},
+				floor: config.PriceFloors{
+					Enabled:           true,
+					EnforceFloorsRate: 100,
+					EnforceDealFloors: true,
+				},
+				conversions:        convert{},
+				responseDebugAllow: true,
+			},
+			want: map[openrtb_ext.BidderName]*pbsOrtbSeatBid{
+				"pubmatic": {
+					bids: []*pbsOrtbBid{
+						{
+							bid: &openrtb2.Bid{
+								ID:     "some-bid-1",
+								Price:  1.2,
+								ImpID:  "some-impression-id-1",
+								DealID: "1",
+							},
+						},
+					},
+					currency: "USD",
+				},
+				"appnexus": {
+					bids:     []*pbsOrtbBid{},
+					currency: "USD",
+				},
+			},
+			want1: []string{"bid rejected [bid ID: some-bid-11] reason: bid price value 0.5000 USD is less than bidFloor value 5.0100 USD for impression id some-impression-id-1 bidder appnexus"},
+		},
+		{
+			name: "Should not enforce floors when imp.bidfloor not provided and req.ext.prebid not provided",
+			args: args{
+				r: func() *AuctionRequest {
+					var wrapper openrtb_ext.RequestWrapper
+					strReq := `{"id":"95d6643c-3da6-40a2-b9ca-12279393ffbf","imp":[{"id":"some-impression-id-1","banner":{"format":[{"w":300,"h":250}],"pos":7,"api":[5,6,7]},"displaymanager":"PubMatic_OpenBid_SDK","displaymanagerver":"1.4.0","instl":1,"tagid":"/43743431/DMDemo","secure":0,"ext":{"appnexus-1":{"placementId":234234},"appnexus-2":{"placementId":9880618},"pubmatic":{"adSlot":"/43743431/DMDemo@300x250","publisherId":"5890","wiid":"42faaac0-9134-41c2-a283-77f1302d00ac","wrapper":{"version":1,"profile":7255}},"prebid":{"floors":{"floorRule":"banner|300x250|www.website1.com","floorRuleValue":20.01}}}}],"app":{"name":"OpenWrapperSample","bundle":"com.pubmatic.openbid.app","domain":"www.website1.com","storeurl":"https://itunes.apple.com/us/app/pubmatic-sdk-app/id1175273098?appnexus_banner_fixedbid=1&fixedbid=1","ver":"1.0","publisher":{"id":"5890"}},"device":{"ua":"Mozilla/5.0 (Linux; Android 9; Android SDK built for x86 Build/PSR1.180720.075; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36","geo":{"lat":37.421998333333335,"lon":-122.08400000000002,"type":1},"lmt":0,"ip":"192.0.2.1","devicetype":4,"make":"Google","model":"Android SDK built for x86","os":"Android","osv":"9","h":1794,"w":1080,"pxratio":2.625,"js":1,"language":"en","carrier":"Android","mccmnc":"310-260","connectiontype":6,"ifa":"07c387f2-e030-428f-8336-42f682150759"},"user":{},"at":1,"tmax":1891525,"cur":["USD"],"source":{"tid":"95d6643c-3da6-40a2-b9ca-12279393ffbf","ext":{"omidpn":"PubMatic","omidpv":"1.2.11-Pubmatic"}},"ext":{}}`
+					_ = json.Unmarshal([]byte(strReq), &wrapper)
+					ar := AuctionRequest{BidRequestWrapper: &wrapper}
+					return &ar
+				}(),
+				seatBids: map[openrtb_ext.BidderName]*pbsOrtbSeatBid{
+					"pubmatic": {
+						bids: []*pbsOrtbBid{
+							{
+								bid: &openrtb2.Bid{
+									ID:     "some-bid-1",
+									Price:  1.2,
+									ImpID:  "some-impression-id-1",
+									DealID: "1",
+								},
+							},
+						},
+						currency: "USD",
+					},
+					"appnexus": {
+						bids: []*pbsOrtbBid{
+							{
+								bid: &openrtb2.Bid{
+									ID:    "some-bid-11",
+									Price: 0.5,
+									ImpID: "some-impression-id-1",
+								},
+							},
+						},
+						currency: "USD",
+					},
+				},
+				floor: config.PriceFloors{
+					Enabled:           true,
+					EnforceFloorsRate: 100,
+					EnforceDealFloors: true,
+				},
+				conversions:        convert{},
+				responseDebugAllow: true,
+			},
+			want: map[openrtb_ext.BidderName]*pbsOrtbSeatBid{
+				"pubmatic": {
+					bids: []*pbsOrtbBid{
+						{
+							bid: &openrtb2.Bid{
+								ID:     "some-bid-1",
+								Price:  1.2,
+								ImpID:  "some-impression-id-1",
+								DealID: "1",
+							},
+						},
+					},
+					currency: "USD",
+				},
+				"appnexus": {
+					bids: []*pbsOrtbBid{
+						{
+							bid: &openrtb2.Bid{
+								ID:    "some-bid-11",
+								Price: 0.5,
+								ImpID: "some-impression-id-1",
+							},
+						},
+					},
+					currency: "USD",
+				},
+			},
+			want1: nil,
+		},
+		{
 			name: "Should not enforce floors when  config flag Enabled = false",
 			args: args{
 				r: func() *AuctionRequest {
@@ -1245,6 +1385,82 @@ func TestEnforceFloors(t *testing.T) {
 				r: func() *AuctionRequest {
 					var wrapper openrtb_ext.RequestWrapper
 					strReq := `{"id":"95d6643c-3da6-40a2-b9ca-12279393ffbf","imp":[{"id":"some-impression-id-1","banner":{"format":[{"w":300,"h":250}],"pos":7,"api":[5,6,7]},"displaymanager":"PubMatic_OpenBid_SDK","displaymanagerver":"1.4.0","instl":1,"tagid":"/43743431/DMDemo","bidfloor":20.01,"bidfloorcur":"USD","secure":0,"ext":{"appnexus-1":{"placementId":234234},"appnexus-2":{"placementId":9880618},"pubmatic":{"adSlot":"/43743431/DMDemo@300x250","publisherId":"5890","wiid":"42faaac0-9134-41c2-a283-77f1302d00ac","wrapper":{"version":1,"profile":7255}},"prebid":{"floors":{"floorRule":"banner|300x250|www.website1.com","floorRuleValue":20.01}}}}],"app":{"name":"OpenWrapperSample","bundle":"com.pubmatic.openbid.app","domain":"www.website1.com","storeurl":"https://itunes.apple.com/us/app/pubmatic-sdk-app/id1175273098?appnexus_banner_fixedbid=1&fixedbid=1","ver":"1.0","publisher":{"id":"5890"}},"device":{"ua":"Mozilla/5.0 (Linux; Android 9; Android SDK built for x86 Build/PSR1.180720.075; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36","geo":{"lat":37.421998333333335,"lon":-122.08400000000002,"type":1},"lmt":0,"ip":"192.0.2.1","devicetype":4,"make":"Google","model":"Android SDK built for x86","os":"Android","osv":"9","h":1794,"w":1080,"pxratio":2.625,"js":1,"language":"en","carrier":"Android","mccmnc":"310-260","connectiontype":6,"ifa":"07c387f2-e030-428f-8336-42f682150759"},"user":{},"at":1,"tmax":1891525,"cur":["USD"],"source":{"tid":"95d6643c-3da6-40a2-b9ca-12279393ffbf","ext":{"omidpn":"PubMatic","omidpv":"1.2.11-Pubmatic"}},"ext":{"prebid":{"aliases":{"adg":"adgeneration","andbeyond":"adkernel","appnexus-1":"appnexus","appnexus-2":"appnexus","districtm":"appnexus","districtmDMX":"dmx","pubmatic2":"pubmatic"},"channel":{"name":"app","version":""},"debug":true,"targeting":{"pricegranularity":{"precision":2,"ranges":[{"min":0,"max":5,"increment":0.05},{"min":5,"max":10,"increment":0.1},{"min":10,"max":20,"increment":0.5}]},"includewinners":true,"includebidderkeys":true,"includebrandcategory":null,"includeformat":false,"durationrangesec":null,"preferdeals":false},"bidderparams":{"pubmatic":{"wiid":"42faaac0-9134-41c2-a283-77f1302d00ac"}},"floors":{"floormin":1,"data":{"currency":"USD","skiprate":100,"modelgroups":[{"modelweight":40,"debugweight":75,"modelversion":"version2","skiprate":10,"schema":{"fields":["mediaType","size","domain"],"delimiter":"|"},"values":{"*|*|*":17.01,"*|*|www.website1.com":16.01,"*|300x250|*":11.01,"*|300x250|www.website1.com":100.01,"*|300x600|*":13.01,"*|300x600|www.website1.com":12.01,"*|728x90|*":15.01,"*|728x90|www.website1.com":14.01,"banner|*|*":90.01,"banner|*|www.website1.com":80.01,"banner|300x250|*":30.01,"banner|300x250|www.website1.com":20.01,"banner|300x600|*":50.01,"banner|300x600|www.website1.com":40.01,"banner|728x90|*":70.01,"banner|728x90|www.website1.com":60.01},"default":21}]},"enforcement":{"enforcepbs":true,"floordeals":true},"enabled":false,"skipped":false}}}}`
+					_ = json.Unmarshal([]byte(strReq), &wrapper)
+					ar := AuctionRequest{BidRequestWrapper: &wrapper}
+					return &ar
+				}(),
+				seatBids: map[openrtb_ext.BidderName]*pbsOrtbSeatBid{
+					"pubmatic": {
+						bids: []*pbsOrtbBid{
+							{
+								bid: &openrtb2.Bid{
+									ID:     "some-bid-1",
+									Price:  1.2,
+									ImpID:  "some-impression-id-1",
+									DealID: "1",
+								},
+							},
+						},
+						currency: "USD",
+					},
+					"appnexus": {
+						bids: []*pbsOrtbBid{
+							{
+								bid: &openrtb2.Bid{
+									ID:     "some-bid-11",
+									Price:  0.5,
+									ImpID:  "some-impression-id-1",
+									DealID: "3",
+								},
+							},
+						},
+						currency: "USD",
+					},
+				},
+				floor: config.PriceFloors{
+					Enabled:           true,
+					EnforceFloorsRate: 100,
+					EnforceDealFloors: true,
+				},
+				conversions:        convert{},
+				responseDebugAllow: true,
+			},
+			want: map[openrtb_ext.BidderName]*pbsOrtbSeatBid{
+				"pubmatic": {
+					bids: []*pbsOrtbBid{
+						{
+							bid: &openrtb2.Bid{
+								ID:     "some-bid-1",
+								Price:  1.2,
+								ImpID:  "some-impression-id-1",
+								DealID: "1",
+							},
+						},
+					},
+					currency: "USD",
+				},
+				"appnexus": {
+					bids: []*pbsOrtbBid{
+						{
+							bid: &openrtb2.Bid{
+								ID:     "some-bid-11",
+								Price:  0.5,
+								ImpID:  "some-impression-id-1",
+								DealID: "3",
+							},
+						},
+					},
+					currency: "USD",
+				},
+			},
+			want1: nil,
+		},
+		{
+			name: "Should not enforce floors when req.ext.prebid.floors.enforcement.enforcepbs = false ",
+			args: args{
+				r: func() *AuctionRequest {
+					var wrapper openrtb_ext.RequestWrapper
+					strReq := `{"id":"95d6643c-3da6-40a2-b9ca-12279393ffbf","imp":[{"id":"some-impression-id-1","banner":{"format":[{"w":300,"h":250}],"pos":7,"api":[5,6,7]},"displaymanager":"PubMatic_OpenBid_SDK","displaymanagerver":"1.4.0","instl":1,"tagid":"/43743431/DMDemo","bidfloor":20.01,"bidfloorcur":"USD","secure":0,"ext":{"appnexus-1":{"placementId":234234},"appnexus-2":{"placementId":9880618},"pubmatic":{"adSlot":"/43743431/DMDemo@300x250","publisherId":"5890","wiid":"42faaac0-9134-41c2-a283-77f1302d00ac","wrapper":{"version":1,"profile":7255}},"prebid":{"floors":{"floorRule":"banner|300x250|www.website1.com","floorRuleValue":20.01}}}}],"app":{"name":"OpenWrapperSample","bundle":"com.pubmatic.openbid.app","domain":"www.website1.com","storeurl":"https://itunes.apple.com/us/app/pubmatic-sdk-app/id1175273098?appnexus_banner_fixedbid=1&fixedbid=1","ver":"1.0","publisher":{"id":"5890"}},"device":{"ua":"Mozilla/5.0 (Linux; Android 9; Android SDK built for x86 Build/PSR1.180720.075; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36","geo":{"lat":37.421998333333335,"lon":-122.08400000000002,"type":1},"lmt":0,"ip":"192.0.2.1","devicetype":4,"make":"Google","model":"Android SDK built for x86","os":"Android","osv":"9","h":1794,"w":1080,"pxratio":2.625,"js":1,"language":"en","carrier":"Android","mccmnc":"310-260","connectiontype":6,"ifa":"07c387f2-e030-428f-8336-42f682150759"},"user":{},"at":1,"tmax":1891525,"cur":["USD"],"source":{"tid":"95d6643c-3da6-40a2-b9ca-12279393ffbf","ext":{"omidpn":"PubMatic","omidpv":"1.2.11-Pubmatic"}},"ext":{"prebid":{"aliases":{"adg":"adgeneration","andbeyond":"adkernel","appnexus-1":"appnexus","appnexus-2":"appnexus","districtm":"appnexus","districtmDMX":"dmx","pubmatic2":"pubmatic"},"channel":{"name":"app","version":""},"debug":true,"targeting":{"pricegranularity":{"precision":2,"ranges":[{"min":0,"max":5,"increment":0.05},{"min":5,"max":10,"increment":0.1},{"min":10,"max":20,"increment":0.5}]},"includewinners":true,"includebidderkeys":true,"includebrandcategory":null,"includeformat":false,"durationrangesec":null,"preferdeals":false},"bidderparams":{"pubmatic":{"wiid":"42faaac0-9134-41c2-a283-77f1302d00ac"}},"floors":{"floormin":1,"data":{"currency":"USD","skiprate":100,"modelgroups":[{"modelweight":40,"debugweight":75,"modelversion":"version2","skiprate":10,"schema":{"fields":["mediaType","size","domain"],"delimiter":"|"},"values":{"*|*|*":17.01,"*|*|www.website1.com":16.01,"*|300x250|*":11.01,"*|300x250|www.website1.com":100.01,"*|300x600|*":13.01,"*|300x600|www.website1.com":12.01,"*|728x90|*":15.01,"*|728x90|www.website1.com":14.01,"banner|*|*":90.01,"banner|*|www.website1.com":80.01,"banner|300x250|*":30.01,"banner|300x250|www.website1.com":20.01,"banner|300x600|*":50.01,"banner|300x600|www.website1.com":40.01,"banner|728x90|*":70.01,"banner|728x90|www.website1.com":60.01},"default":21}]},"enforcement":{"enforcepbs":false,"floordeals":false}}}}}`
 					_ = json.Unmarshal([]byte(strReq), &wrapper)
 					ar := AuctionRequest{BidRequestWrapper: &wrapper}
 					return &ar

--- a/floors/enforce.go
+++ b/floors/enforce.go
@@ -5,7 +5,7 @@ import (
 	"github.com/prebid/prebid-server/openrtb_ext"
 )
 
-func requestHasFloors(bidRequest *openrtb2.BidRequest) bool {
+func RequestHasFloors(bidRequest *openrtb2.BidRequest) bool {
 	for i := range bidRequest.Imp {
 		if bidRequest.Imp[i].BidFloor > 0 {
 			return true
@@ -17,7 +17,7 @@ func requestHasFloors(bidRequest *openrtb2.BidRequest) bool {
 func ShouldEnforce(bidRequest *openrtb2.BidRequest, floorExt *openrtb_ext.PriceFloorRules, configEnforceRate int, f func(int) int) bool {
 
 	if floorExt != nil && floorExt.Skipped != nil && *floorExt.Skipped {
-		floorInRequest := requestHasFloors(bidRequest)
+		floorInRequest := RequestHasFloors(bidRequest)
 		if !floorInRequest {
 			return floorInRequest
 		}


### PR DESCRIPTION


# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
