### PR TITLE
OTT-782-Prebid: As prebid server floors user, use imp[].ext.prebid.floors.floorMin to set floors values for each impression

### DIFF
--- a/floors/floors.go
+++ b/floors/floors.go
@@ -85,7 +85,7 @@ func updateBidRequestWithFloors(extFloorRules *openrtb_ext.PriceFloorRules, requ
 				floorVal = modelGroup.Values[matchedRule]
 			}
 
-			floorMinVal, floorCur, err := getMinFloorValue(extFloorRules, conversions)
+			floorMinVal, floorCur, err := getMinFloorValue(extFloorRules, request.Imp[i], conversions)
 			if err == nil {
 				floorVal = math.Round(floorVal*10000) / 10000
 				bidFloor := floorVal

--- a/floors/rule.go
+++ b/floors/rule.go
@@ -73,13 +73,14 @@ func getMinFloorValue(floorExt *openrtb_ext.PriceFloorRules, imp openrtb2.Imp, c
 			floorMinCur = floorCurValue
 		}
 	}
-	if floorMin > float64(0) && floorMinCur != "" && floorExt.FloorMinCur != floorCurValue {
-		glog.Warning("FloorMinCur are different in floorExt and ImpExt")
-	}
-	if floorMin > float64(0) && floorMinCur != "" && floorCur != "" &&
-		floorMinCur != floorCur {
-		rate, err = conversions.GetRate(floorMinCur, floorCur)
-		floorMin = rate * floorMin
+	if floorMin > float64(0) && floorMinCur != "" {
+		if floorExt.FloorMinCur != floorCurValue {
+			glog.Warning("FloorMinCur are different in floorExt and ImpExt")
+		}
+		if floorCur != "" && floorMinCur != floorCur {
+			rate, err = conversions.GetRate(floorMinCur, floorCur)
+			floorMin = rate * floorMin
+		}
 	}
 	floorMin = math.Round(floorMin*10000) / 10000
 	return floorMin, floorCur, err
@@ -95,7 +96,7 @@ func getFloorMinAndCurFromImp(imp openrtb2.Imp) (float64, string, error) {
 			return floorMin, "", fmt.Errorf("error decoding Request.ext : %s", err.Error())
 		}
 	}
-	if impExt.Prebid != nil && &impExt.Prebid.Floors != nil {
+	if impExt.Prebid != nil {
 		if impExt.Prebid.Floors.FloorMin > float64(0) {
 			floorMin = impExt.Prebid.Floors.FloorMin
 		}

--- a/floors/rule.go
+++ b/floors/rule.go
@@ -74,7 +74,7 @@ func getMinFloorValue(floorExt *openrtb_ext.PriceFloorRules, imp openrtb2.Imp, c
 		}
 	}
 	if floorMin > float64(0) && floorMinCur != "" && floorExt.FloorMinCur != floorCurValue {
-		glog.Warning("FloorMinCur doesn't match")
+		glog.Warning("FloorMinCur are different in floorExt and ImpExt")
 	}
 	if floorMin > float64(0) && floorMinCur != "" && floorCur != "" &&
 		floorMinCur != floorCur {

--- a/floors/rule.go
+++ b/floors/rule.go
@@ -74,7 +74,7 @@ func getMinFloorValue(floorExt *openrtb_ext.PriceFloorRules, imp openrtb2.Imp, c
 		}
 	}
 	if floorMin > float64(0) && floorMinCur != "" {
-		if floorExt.FloorMinCur != floorCurValue {
+		if floorExt.FloorMinCur != "" && floorCurValue != "" && floorExt.FloorMinCur != floorCurValue {
 			glog.Warning("FloorMinCur are different in floorExt and ImpExt")
 		}
 		if floorCur != "" && floorMinCur != floorCur {

--- a/floors/rule.go
+++ b/floors/rule.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/buger/jsonparser"
+	"github.com/golang/glog"
 	"github.com/mxmCherry/openrtb/v16/openrtb2"
 	"github.com/prebid/prebid-server/currency"
 	"github.com/prebid/prebid-server/openrtb_ext"
@@ -53,25 +54,56 @@ func getFloorCurrency(floorExt *openrtb_ext.PriceFloorRules) string {
 	return floorCur
 }
 
-func getMinFloorValue(floorExt *openrtb_ext.PriceFloorRules, conversions currency.Conversions) (float64, string, error) {
+func getMinFloorValue(floorExt *openrtb_ext.PriceFloorRules, imp openrtb2.Imp, conversions currency.Conversions) (float64, string, error) {
 	var err error
 	var rate float64
 
-	if floorExt == nil {
-		return 0, "USD", err
-	}
 	floorMin := floorExt.FloorMin
+	floorMinCur := floorExt.FloorMinCur
 	floorCur := getFloorCurrency(floorExt)
 	if len(floorCur) == 0 {
 		floorCur = "USD"
 	}
-	if floorMin > float64(0) && floorExt.FloorMinCur != "" && floorCur != "" &&
-		floorExt.FloorMinCur != floorCur {
-		rate, err = conversions.GetRate(floorExt.FloorMinCur, floorCur)
+	floorMinValue, floorCurValue, err := getFloorMinAndCurFromImp(imp)
+	if err == nil {
+		if floorMinValue > 0.0 {
+			floorMin = floorMinValue
+		}
+		if floorCurValue != "" {
+			floorMinCur = floorCurValue
+		}
+	}
+	if floorMin > float64(0) && floorMinCur != "" && floorExt.FloorMinCur != floorCurValue {
+		glog.Warning("FloorMinCur doesn't match")
+	}
+	if floorMin > float64(0) && floorMinCur != "" && floorCur != "" &&
+		floorMinCur != floorCur {
+		rate, err = conversions.GetRate(floorMinCur, floorCur)
 		floorMin = rate * floorMin
 	}
 	floorMin = math.Round(floorMin*10000) / 10000
 	return floorMin, floorCur, err
+}
+
+func getFloorMinAndCurFromImp(imp openrtb2.Imp) (float64, string, error) {
+	impExt := openrtb_ext.ExtImp{}
+	var floorMin float64
+	var floorMinCur string
+	if len(imp.Ext) > 0 {
+		err := json.Unmarshal(imp.Ext, &impExt)
+		if err != nil {
+			return floorMin, "", fmt.Errorf("error decoding Request.ext : %s", err.Error())
+		}
+	}
+	if impExt.Prebid != nil && &impExt.Prebid.Floors != nil {
+		if impExt.Prebid.Floors.FloorMin > 0.0 {
+			floorMin = impExt.Prebid.Floors.FloorMin
+		}
+		if impExt.Prebid.Floors.FloorMinCur != "" {
+			floorMinCur = impExt.Prebid.Floors.FloorMinCur
+		}
+	}
+	return floorMin, floorMinCur, nil
 }
 
 func updateImpExtWithFloorDetails(imp *openrtb2.Imp, matchedRule string, floorRuleVal, floorVal float64) {

--- a/floors/rule.go
+++ b/floors/rule.go
@@ -96,7 +96,7 @@ func getFloorMinAndCurFromImp(imp openrtb2.Imp) (float64, string, error) {
 		}
 	}
 	if impExt.Prebid != nil && &impExt.Prebid.Floors != nil {
-		if impExt.Prebid.Floors.FloorMin > 0.0 {
+		if impExt.Prebid.Floors.FloorMin > float64(0) {
 			floorMin = impExt.Prebid.Floors.FloorMin
 		}
 		if impExt.Prebid.Floors.FloorMinCur != "" {

--- a/openrtb_ext/floors.go
+++ b/openrtb_ext/floors.go
@@ -1,5 +1,7 @@
 package openrtb_ext
 
+import "encoding/json"
+
 // Defines strings for FetchStatus
 const (
 	FetchSuccess    = "success"
@@ -69,6 +71,21 @@ type ImpFloorExt struct {
 	FloorRule      string  `json:"floorRule,omitempty"`
 	FloorRuleValue float64 `json:"floorRuleValue,omitempty"`
 	FloorValue     float64 `json:"floorValue,omitempty"`
+}
+type Price struct {
+	FloorMin    float64 `json:"floormin,omitempty"`
+	FloorMinCur string  `json:"floormincur,omitempty"`
+}
+
+type ExtImp struct {
+	Prebid *ImpExtPrebid `json:"prebid,omitempty"`
+}
+
+// ExtImpPrebid defines the contract for bidrequest.imp[i].ext.prebid
+type ImpExtPrebid struct {
+	Options     *Options        `json:"options,omitempty"`
+	Passthrough json.RawMessage `json:"passthrough,omitempty"`
+	Floors      Price           `json:"floors,omitempty"`
 }
 
 // GetEnabled will check if floors is enabled in request

--- a/openrtb_ext/floors.go
+++ b/openrtb_ext/floors.go
@@ -81,7 +81,6 @@ type ExtImp struct {
 	Prebid *ImpExtPrebid `json:"prebid,omitempty"`
 }
 
-// ExtImpPrebid defines the contract for bidrequest.imp[i].ext.prebid
 type ImpExtPrebid struct {
 	Options     *Options        `json:"options,omitempty"`
 	Passthrough json.RawMessage `json:"passthrough,omitempty"`

--- a/openrtb_ext/floors.go
+++ b/openrtb_ext/floors.go
@@ -1,7 +1,5 @@
 package openrtb_ext
 
-import "encoding/json"
-
 // Defines strings for FetchStatus
 const (
 	FetchSuccess    = "success"
@@ -82,9 +80,7 @@ type ExtImp struct {
 }
 
 type ImpExtPrebid struct {
-	Options     *Options        `json:"options,omitempty"`
-	Passthrough json.RawMessage `json:"passthrough,omitempty"`
-	Floors      Price           `json:"floors,omitempty"`
+	Floors Price `json:"floors,omitempty"`
 }
 
 // GetEnabled will check if floors is enabled in request


### PR DESCRIPTION
# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
