### PR TITLE
OTT-791: Using bucketMin in price bucket calculations

### DIFF
--- a/exchange/price_granularity.go
+++ b/exchange/price_granularity.go
@@ -13,7 +13,7 @@ func GetPriceBucket(cpm float64, config openrtb_ext.PriceGranularity) string {
 	bucketMax := 0.0
 	increment := 0.0
 	precision := config.Precision
-
+	bucketMin := 0.0
 	for i := 0; i < len(config.Ranges); i++ {
 		if config.Ranges[i].Max > bucketMax {
 			bucketMax = config.Ranges[i].Max
@@ -21,6 +21,7 @@ func GetPriceBucket(cpm float64, config openrtb_ext.PriceGranularity) string {
 		// find what range cpm is in
 		if cpm >= config.Ranges[i].Min && cpm <= config.Ranges[i].Max {
 			increment = config.Ranges[i].Increment
+			bucketMin = config.Ranges[i].Min
 		}
 	}
 
@@ -30,13 +31,13 @@ func GetPriceBucket(cpm float64, config openrtb_ext.PriceGranularity) string {
 		cpmStr = strconv.FormatFloat(bucketMax, 'f', precision, 64)
 	} else if increment > 0 {
 		// If increment exists, get cpm string value
-		cpmStr = getCpmTarget(cpm, increment, precision)
+		cpmStr = getCpmTarget(cpm, bucketMin, increment, precision)
 	}
 
 	return cpmStr
 }
 
-func getCpmTarget(cpm float64, increment float64, precision int) string {
-	roundedCPM := math.Floor(cpm/increment) * increment
+func getCpmTarget(cpm float64, bucketMin float64, increment float64, precision int) string {
+	roundedCPM := math.Floor((cpm-bucketMin)/increment)*increment + bucketMin
 	return strconv.FormatFloat(roundedCPM, 'f', precision, 64)
 }

--- a/exchange/price_granularity_test.go
+++ b/exchange/price_granularity_test.go
@@ -31,6 +31,22 @@ func TestGetPriceBucketString(t *testing.T) {
 		},
 	}
 
+	custom2 := openrtb_ext.PriceGranularity{
+		Precision: 2,
+		Ranges: []openrtb_ext.GranularityRange{
+			{
+				Min:       0.0,
+				Max:       2.5,
+				Increment: 1.0,
+			},
+			{
+				Min:       2.5,
+				Max:       10.0,
+				Increment: 1.2,
+			},
+		},
+	}
+
 	// Define test cases
 	type aTest struct {
 		granularityId       string
@@ -53,6 +69,7 @@ func TestGetPriceBucketString(t *testing.T) {
 				{"dense", dense, "1.87"},
 				{"testpg", testPG, "50.00"},
 				{"custom1", custom1, "1.86"},
+				{"custom2", custom2, "1.00"},
 			},
 		},
 		{
@@ -66,6 +83,7 @@ func TestGetPriceBucketString(t *testing.T) {
 				{"dense", dense, "5.70"},
 				{"testpg", testPG, "50.00"},
 				{"custom1", custom1, "5.70"},
+				{"custom2", custom2, "4.90"},
 			},
 		},
 		{


### PR DESCRIPTION
# Description

OTT-791: Using bucketMin in price bucket calculations

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
