### PR TITLE
OTT-786: Reverting (set bid status wrt to highest(winning) combination)

### DIFF
--- a/analytics/core_ow.go
+++ b/analytics/core_ow.go
@@ -11,5 +11,4 @@ type RejectedBid struct {
 	RejectionReason openrtb3.LossReason
 	Bid             *openrtb2.Bid
 	Seat            string
-	BidderName      string
 }

--- a/endpoints/openrtb2/ctv/response/adpod_generator.go
+++ b/endpoints/openrtb2/ctv/response/adpod_generator.go
@@ -174,6 +174,11 @@ func (o *AdPodGenerator) getMaxAdPodBid(results []*highestCombination) *types.Ad
 	//Get Max Response
 	var maxResult *highestCombination
 	for _, result := range results {
+		for _, rc := range result.filteredBids {
+			if constant.StatusOK == rc.bid.Status {
+				rc.bid.Status = rc.status
+			}
+		}
 		if len(result.bidIDs) == 0 {
 			continue
 		}
@@ -187,15 +192,9 @@ func (o *AdPodGenerator) getMaxAdPodBid(results []*highestCombination) *types.Ad
 
 	if nil == maxResult {
 		util.Logf("Tid:%v ImpId:%v All Combination Filtered in Ad Exclusion", o.request.ID, o.request.Imp[o.impIndex].ID)
-		// if all the combinations are filtered then update rejections reason for all
-		// the combinations. In case same bids is rejected in multiple combination
-		// then reason from the last combination in iteration will be used.
-		updateRejectionStatus(results)
 		return nil
 	}
 
-	// Update the rejection reason for bids filters in winning combination
-	updateRejectionStatus([]*highestCombination{maxResult})
 	adpodBid := &types.AdPodBid{
 		Bids:    maxResult.bids[:],
 		Price:   maxResult.price,
@@ -216,16 +215,6 @@ func (o *AdPodGenerator) getMaxAdPodBid(results []*highestCombination) *types.Ad
 	util.Logf("Tid:%v ImpId:%v Selected Durations:%v Price:%v Bids:%v", o.request.ID, o.request.Imp[o.impIndex].ID, maxResult.durations[:], maxResult.price, maxResult.bidIDs[:])
 
 	return adpodBid
-}
-
-func updateRejectionStatus(results []*highestCombination) {
-	for _, result := range results {
-		for _, rc := range result.filteredBids {
-			if constant.StatusOK == rc.bid.Status {
-				rc.bid.Status = rc.status
-			}
-		}
-	}
 }
 
 func (o *AdPodGenerator) getUniqueBids(durationSequence []int) *highestCombination {

--- a/endpoints/openrtb2/ctv/response/adpod_generator_test.go
+++ b/endpoints/openrtb2/ctv/response/adpod_generator_test.go
@@ -94,15 +94,13 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 		impIndex int
 	}
 	type args struct {
-		results         []*highestCombination
-		getFilteredBids func(results []*highestCombination) []*types.Bid
+		results []*highestCombination
 	}
 	tests := []struct {
-		name                 string
-		fields               fields
-		args                 args
-		want                 *types.AdPodBid
-		expectedFilteredBids []*types.Bid
+		name   string
+		fields fields
+		args   args
+		want   *types.AdPodBid
 	}{
 		{
 			name: `EmptyResults`,
@@ -112,20 +110,8 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 			},
 			args: args{
 				results: nil,
-				getFilteredBids: func(results []*highestCombination) []*types.Bid {
-					filteredIds := []string{}
-					bids := []*types.Bid{}
-
-					for _, result := range results {
-						for _, fb := range filteredIds {
-							bids = append(bids, result.filteredBids[fb].bid)
-						}
-					}
-					return bids
-				},
 			},
-			want:                 nil,
-			expectedFilteredBids: []*types.Bid{},
+			want: nil,
 		},
 		{
 			name: `AllBidsFiltered`,
@@ -143,19 +129,8 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 						},
 					},
 				},
-				getFilteredBids: func(results []*highestCombination) []*types.Bid {
-					filteredIds := []string{"bid-1", "bid-2", "bid-3"}
-					bids := []*types.Bid{}
-					for _, result := range results {
-						for _, fb := range filteredIds {
-							bids = append(bids, result.filteredBids[fb].bid)
-						}
-					}
-					return bids
-				},
 			},
-			want:                 nil,
-			expectedFilteredBids: []*types.Bid{{Bid: &openrtb2.Bid{ID: `bid-1`}, Status: constant.StatusCategoryExclusion}, {Bid: &openrtb2.Bid{ID: `bid-2`}, Status: constant.StatusCategoryExclusion}, {Bid: &openrtb2.Bid{ID: `bid-3`}, Status: constant.StatusCategoryExclusion}},
+			want: nil,
 		},
 		{
 			name: `SingleResponse`,
@@ -187,16 +162,6 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 						},
 					},
 				},
-				getFilteredBids: func(results []*highestCombination) []*types.Bid {
-					filteredIds := []string{"bid-4"}
-					bids := []*types.Bid{}
-					for _, result := range results {
-						for _, fb := range filteredIds {
-							bids = append(bids, result.filteredBids[fb].bid)
-						}
-					}
-					return bids
-				},
 			},
 			want: &types.AdPodBid{
 				Bids: []*types.Bid{
@@ -208,7 +173,6 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 				ADomain: []string{`domain-1`, `domain-2`},
 				Price:   20,
 			},
-			expectedFilteredBids: []*types.Bid{{Bid: &openrtb2.Bid{ID: `bid-4`}, Status: constant.StatusCategoryExclusion}},
 		},
 		{
 			name: `MultiResponse-AllNonDealBids`,
@@ -225,9 +189,6 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 						bidIDs:    []string{`bid-11`},
 						price:     10,
 						nDealBids: 0,
-						filteredBids: map[string]*filteredBid{
-							`bid-12`: {bid: &types.Bid{Bid: &openrtb2.Bid{ID: `bid-12`}}, status: constant.StatusCategoryExclusion},
-						},
 					},
 					{
 						bids: []*types.Bid{
@@ -236,9 +197,6 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 						bidIDs:    []string{`bid-21`},
 						price:     20,
 						nDealBids: 0,
-						filteredBids: map[string]*filteredBid{
-							`bid-22`: {bid: &types.Bid{Bid: &openrtb2.Bid{ID: `bid-22`}}, status: constant.StatusCategoryExclusion},
-						},
 					},
 					{
 						bids: []*types.Bid{
@@ -247,9 +205,6 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 						bidIDs:    []string{`bid-31`},
 						price:     10,
 						nDealBids: 0,
-						filteredBids: map[string]*filteredBid{
-							`bid-32`: {bid: &types.Bid{Bid: &openrtb2.Bid{ID: `bid-32`}}, status: constant.StatusCategoryExclusion},
-						},
 					},
 					{
 						bids: []*types.Bid{
@@ -258,22 +213,7 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 						bidIDs:    []string{`bid-41`},
 						price:     15,
 						nDealBids: 0,
-						filteredBids: map[string]*filteredBid{
-							`bid-42`: {bid: &types.Bid{Bid: &openrtb2.Bid{ID: `bid-42`}}, status: constant.StatusCategoryExclusion},
-						},
 					},
-				},
-				getFilteredBids: func(results []*highestCombination) []*types.Bid {
-					filteredIds := []string{"bid-22"}
-					bids := []*types.Bid{}
-					for _, result := range results {
-						for _, fb := range filteredIds {
-							if _, ok := result.filteredBids[fb]; ok {
-								bids = append(bids, result.filteredBids[fb].bid)
-							}
-						}
-					}
-					return bids
 				},
 			},
 			want: &types.AdPodBid{
@@ -284,7 +224,6 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 				ADomain: []string{},
 				Price:   20,
 			},
-			expectedFilteredBids: []*types.Bid{{Bid: &openrtb2.Bid{ID: `bid-22`}, Status: constant.StatusCategoryExclusion}},
 		},
 		{
 			name: `MultiResponse-AllDealBids-SameCount`,
@@ -301,9 +240,6 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 						bidIDs:    []string{`bid-11`},
 						price:     10,
 						nDealBids: 1,
-						filteredBids: map[string]*filteredBid{
-							`bid-12`: {bid: &types.Bid{Bid: &openrtb2.Bid{ID: `bid-12`}}, status: constant.StatusDomainExclusion},
-						},
 					},
 					{
 						bids: []*types.Bid{
@@ -330,18 +266,6 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 						nDealBids: 1,
 					},
 				},
-				getFilteredBids: func(results []*highestCombination) []*types.Bid {
-					filteredIds := []string{"bid-22"}
-					bids := []*types.Bid{}
-					for _, result := range results {
-						for _, fb := range filteredIds {
-							if _, ok := result.filteredBids[fb]; ok {
-								bids = append(bids, result.filteredBids[fb].bid)
-							}
-						}
-					}
-					return bids
-				},
 			},
 			want: &types.AdPodBid{
 				Bids: []*types.Bid{
@@ -351,7 +275,6 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 				ADomain: []string{},
 				Price:   20,
 			},
-			expectedFilteredBids: []*types.Bid{},
 		},
 		{
 			name: `MultiResponse-AllDealBids-DifferentCount`,
@@ -394,18 +317,6 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 						nDealBids: 2,
 					},
 				},
-				getFilteredBids: func(results []*highestCombination) []*types.Bid {
-					filteredIds := []string{"bid-22"}
-					bids := []*types.Bid{}
-					for _, result := range results {
-						for _, fb := range filteredIds {
-							if _, ok := result.filteredBids[fb]; ok {
-								bids = append(bids, result.filteredBids[fb].bid)
-							}
-						}
-					}
-					return bids
-				},
 			},
 			want: &types.AdPodBid{
 				Bids: []*types.Bid{
@@ -415,7 +326,6 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 				ADomain: []string{},
 				Price:   10,
 			},
-			expectedFilteredBids: []*types.Bid{},
 		},
 		{
 			name: `MultiResponse-Mixed-DealandNonDealBids`,
@@ -448,9 +358,6 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 						bidIDs:    []string{`bid-31`},
 						price:     10,
 						nDealBids: 3,
-						filteredBids: map[string]*filteredBid{
-							`bid-32`: {bid: &types.Bid{Bid: &openrtb2.Bid{ID: `bid-32`}}, status: constant.StatusDomainExclusion},
-						},
 					},
 					{
 						bids: []*types.Bid{
@@ -461,18 +368,6 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 						nDealBids: 0,
 					},
 				},
-				getFilteredBids: func(results []*highestCombination) []*types.Bid {
-					filteredIds := []string{"bid-32"}
-					bids := []*types.Bid{}
-					for _, result := range results {
-						for _, fb := range filteredIds {
-							if _, ok := result.filteredBids[fb]; ok {
-								bids = append(bids, result.filteredBids[fb].bid)
-							}
-						}
-					}
-					return bids
-				},
 			},
 			want: &types.AdPodBid{
 				Bids: []*types.Bid{
@@ -482,8 +377,8 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 				ADomain: []string{},
 				Price:   10,
 			},
-			expectedFilteredBids: []*types.Bid{{Bid: &openrtb2.Bid{ID: `bid-32`}, Status: constant.StatusDomainExclusion}},
 		},
+		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -497,8 +392,6 @@ func TestAdPodGenerator_getMaxAdPodBid(t *testing.T) {
 				sort.Strings(got.Cat)
 			}
 			assert.Equal(t, tt.want, got)
-			filteredBids := tt.args.getFilteredBids(tt.args.results)
-			assert.Equal(t, tt.expectedFilteredBids, filteredBids, "Filtered Bids mismatch")
 		})
 	}
 }

--- a/exchange/floors.go
+++ b/exchange/floors.go
@@ -77,9 +77,8 @@ func enforceFloorToBids(bidRequest *openrtb2.BidRequest, seatBids map[openrtb_ex
 					bidPrice := rate * bid.bid.Price
 					if reqImp.BidFloor > bidPrice {
 						rejectedBid := analytics.RejectedBid{
-							Bid:        bid.bid,
-							Seat:       seatBid.seat,
-							BidderName: string(bidderName),
+							Bid:  bid.bid,
+							Seat: seatBid.seat,
 						}
 						rejectedBid.RejectionReason = openrtb3.LossBelowAuctionFloor
 						if bid.bid.DealID != "" {


### PR DESCRIPTION
# Description

OTT-786: Reverting (set bid status wrt to highest(winning) combination)
# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
