### PR TITLE
UOE-8566: Pass Bidviewability-data to pubmatic adserver

### DIFF
--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -61,7 +61,6 @@ type ExtImpBidderPubmatic struct {
 	adapters.ExtImpBidder
 	Data        json.RawMessage `json:"data,omitempty"`
 	SKAdnetwork json.RawMessage `json:"skadn,omitempty"`
-	BidViewabilityScore *openrtb_ext.ExtBidViewabilityScore `json:"bidViewability,omitempty"`
 }
 
 type ExtAdServer struct {

--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -30,6 +30,7 @@ const (
 	urlEncodedEqualChar = "%3D"
 	AdServerKey         = "adserver"
 	PBAdslotKey         = "pbadslot"
+	bidViewability      = "bidViewability"
 )
 
 type PubmaticAdapter struct {
@@ -60,6 +61,7 @@ type ExtImpBidderPubmatic struct {
 	adapters.ExtImpBidder
 	Data        json.RawMessage `json:"data,omitempty"`
 	SKAdnetwork json.RawMessage `json:"skadn,omitempty"`
+	BidViewabilityScore *openrtb_ext.ExtBidViewabilityScore `json:"bidViewability,omitempty"`
 }
 
 type ExtAdServer struct {
@@ -379,6 +381,10 @@ func parseImpressionObject(imp *openrtb2.Imp, extractWrapperExtFromImp, extractP
 
 	if len(bidderExt.Data) > 0 {
 		populateFirstPartyDataImpAttributes(bidderExt.Data, extMap)
+	}
+	// If bidViewabilityScore param is populated, pass it to imp[i].ext
+	if pubmaticExt.BidViewabilityScore != nil {
+		extMap[bidViewability] = *pubmaticExt.BidViewabilityScore
 	}
 
 	imp.Ext = nil

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -88,6 +88,7 @@ func TestParseImpressionObject(t *testing.T) {
 		expectedPublisherId string
 		wantErr             bool
 		expectedBidfloor    float64
+		expectedImpExt      json.RawMessage
 	}{
 		{
 			name: "imp.bidfloor empty and kadfloor set",
@@ -98,6 +99,7 @@ func TestParseImpressionObject(t *testing.T) {
 				},
 			},
 			expectedBidfloor: 0.12,
+			expectedImpExt:   json.RawMessage(nil),
 		},
 		{
 			name: "imp.bidfloor set and kadfloor empty",
@@ -109,6 +111,7 @@ func TestParseImpressionObject(t *testing.T) {
 				},
 			},
 			expectedBidfloor: 0.12,
+			expectedImpExt:   json.RawMessage(nil),
 		},
 		{
 			name: "imp.bidfloor set and kadfloor invalid",
@@ -120,6 +123,7 @@ func TestParseImpressionObject(t *testing.T) {
 				},
 			},
 			expectedBidfloor: 0.12,
+			expectedImpExt:   json.RawMessage(nil),
 		},
 		{
 			name: "imp.bidfloor set and kadfloor set, preference to kadfloor",
@@ -131,6 +135,7 @@ func TestParseImpressionObject(t *testing.T) {
 				},
 			},
 			expectedBidfloor: 0.11,
+			expectedImpExt:   json.RawMessage(nil),
 		},
 		{
 			name: "kadfloor string set with whitespace",
@@ -142,6 +147,17 @@ func TestParseImpressionObject(t *testing.T) {
 				},
 			},
 			expectedBidfloor: 0.13,
+			expectedImpExt:   json.RawMessage(nil),
+		},
+		{
+			name: "bidViewability Object is set in imp.ext.prebid.pubmatic, pass to imp.ext",
+			args: args{
+				imp: &openrtb2.Imp{
+					Video: &openrtb2.Video{},
+					Ext:   json.RawMessage(`{"bidder":{"bidViewability":{"rendered":131,"viewed":80,"createdAt":1666155076240,"updatedAt":1666296333802,"lastViewed":3171.100000023842,"totalViewTime":15468}}}`),
+				},
+			},
+			expectedImpExt: json.RawMessage(`{"bidViewability":{"rendered":131,"viewed":80,"createdAt":1666155076240,"updatedAt":1666296333802,"lastViewed":3171.100000023842,"totalViewTime":15468}}`),
 		},
 	}
 	for _, tt := range tests {
@@ -151,6 +167,7 @@ func TestParseImpressionObject(t *testing.T) {
 			assert.Equal(t, tt.expectedWrapperExt, receivedWrapperExt)
 			assert.Equal(t, tt.expectedPublisherId, receivedPublisherId)
 			assert.Equal(t, tt.expectedBidfloor, tt.args.imp.BidFloor)
+			assert.Equal(t, tt.expectedImpExt, tt.args.imp.Ext)
 		})
 	}
 }

--- a/openrtb_ext/imp_pubmatic.go
+++ b/openrtb_ext/imp_pubmatic.go
@@ -9,13 +9,13 @@ import "encoding/json"
 // WrapExt needs to be sent once per bid request
 
 type ExtImpPubmatic struct {
-	PublisherId string                  `json:"publisherId"`
-	AdSlot      string                  `json:"adSlot"`
-	Dctr        string                  `json:"dctr,omitempty"`
-	PmZoneID    string                  `json:"pmzoneid,omitempty"`
-	WrapExt     json.RawMessage         `json:"wrapper,omitempty"`
-	Keywords    []*ExtImpPubmaticKeyVal `json:"keywords,omitempty"`
-	Kadfloor    string                  `json:"kadfloor,omitempty"`
+	PublisherId         string                  `json:"publisherId"`
+	AdSlot              string                  `json:"adSlot"`
+	Dctr                string                  `json:"dctr,omitempty"`
+	PmZoneID            string                  `json:"pmzoneid,omitempty"`
+	WrapExt             json.RawMessage         `json:"wrapper,omitempty"`
+	Keywords            []*ExtImpPubmaticKeyVal `json:"keywords,omitempty"`
+	Kadfloor            string                  `json:"kadfloor,omitempty"`
 	BidViewabilityScore *ExtBidViewabilityScore `json:"bidViewability,omitempty"`
 }
 

--- a/openrtb_ext/imp_pubmatic.go
+++ b/openrtb_ext/imp_pubmatic.go
@@ -16,10 +16,21 @@ type ExtImpPubmatic struct {
 	WrapExt     json.RawMessage         `json:"wrapper,omitempty"`
 	Keywords    []*ExtImpPubmaticKeyVal `json:"keywords,omitempty"`
 	Kadfloor    string                  `json:"kadfloor,omitempty"`
+	BidViewabilityScore *ExtBidViewabilityScore `json:"bidViewability,omitempty"`
 }
 
 // ExtImpPubmaticKeyVal defines the contract for bidrequest.imp[i].ext.pubmatic.keywords[i]
 type ExtImpPubmaticKeyVal struct {
 	Key    string   `json:"key,omitempty"`
 	Values []string `json:"value,omitempty"`
+}
+
+//ExtBidViewabilityScore defines the contract for bidrequest.imp[i].ext.pubmatic.bidViewability
+type ExtBidViewabilityScore struct {
+	Rendered      int     `json:"rendered,omitempty"`
+	Viewed        int     `json:"viewed,omitempty"`
+	CreatedAt     int     `json:"createdAt,omitempty"`
+	UpdatedAt     int     `json:"updatedAt,omitempty"`
+	LastViewed    float64 `json:"lastViewed,omitempty"`
+	TotalViewTime float64 `json:"totalViewTime,omitempty"`
 }


### PR DESCRIPTION
# Description

 Passing BidviewabilityScore, when present, to translator impression extension and exclusive to pubmatic only

# Checklist:

- [x] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [x] JIRA number is added in the PR title and the commit message.
- [x] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.(pending)

