### PR TITLE
OTT-914: Renaming Adpod Configurations

### DIFF
--- a/endpoints/openrtb2/ctv/impressions/by_duration_range_test.go
+++ b/endpoints/openrtb2/ctv/impressions/by_duration_range_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestGetImpressionsByDurationRanges(t *testing.T) {
 	type args struct {
-		policy        openrtb_ext.OWVideoLengthMatchingPolicy
+		policy        openrtb_ext.OWVideoAdDurationMatchingPolicy
 		durations     []int
 		maxAds        int
 		adMinDuration int
@@ -55,7 +55,7 @@ func TestGetImpressionsByDurationRanges(t *testing.T) {
 		{
 			name: "zero_valid_durations_under_boundary",
 			args: args{
-				policy:        openrtb_ext.OWExactVideoLengthsMatching,
+				policy:        openrtb_ext.OWExactVideoAdDurationMatching,
 				durations:     []int{5, 10, 15},
 				maxAds:        5,
 				adMinDuration: 2,
@@ -68,7 +68,7 @@ func TestGetImpressionsByDurationRanges(t *testing.T) {
 		{
 			name: "zero_valid_durations_out_of_bound",
 			args: args{
-				policy:        openrtb_ext.OWExactVideoLengthsMatching,
+				policy:        openrtb_ext.OWExactVideoAdDurationMatching,
 				durations:     []int{5, 10, 15},
 				maxAds:        5,
 				adMinDuration: 20,
@@ -81,7 +81,7 @@ func TestGetImpressionsByDurationRanges(t *testing.T) {
 		{
 			name: "valid_durations_less_than_maxAds",
 			args: args{
-				policy:        openrtb_ext.OWExactVideoLengthsMatching,
+				policy:        openrtb_ext.OWExactVideoAdDurationMatching,
 				durations:     []int{5, 10, 15, 20, 25},
 				maxAds:        5,
 				adMinDuration: 10,
@@ -101,7 +101,7 @@ func TestGetImpressionsByDurationRanges(t *testing.T) {
 		{
 			name: "valid_durations_greater_than_maxAds",
 			args: args{
-				policy:        openrtb_ext.OWExactVideoLengthsMatching,
+				policy:        openrtb_ext.OWExactVideoAdDurationMatching,
 				durations:     []int{5, 10, 15, 20, 25},
 				maxAds:        2,
 				adMinDuration: 10,
@@ -118,7 +118,7 @@ func TestGetImpressionsByDurationRanges(t *testing.T) {
 		{
 			name: "roundup_policy_valid_durations",
 			args: args{
-				policy:        openrtb_ext.OWRoundupVideoLengthMatching,
+				policy:        openrtb_ext.OWRoundupVideoAdDurationMatching,
 				durations:     []int{5, 10, 15, 20, 25},
 				maxAds:        5,
 				adMinDuration: 10,
@@ -137,7 +137,7 @@ func TestGetImpressionsByDurationRanges(t *testing.T) {
 		{
 			name: "roundup_policy_zero_valid_durations",
 			args: args{
-				policy:        openrtb_ext.OWRoundupVideoLengthMatching,
+				policy:        openrtb_ext.OWRoundupVideoAdDurationMatching,
 				durations:     []int{5, 10, 15, 20, 25},
 				maxAds:        5,
 				adMinDuration: 30,
@@ -150,7 +150,7 @@ func TestGetImpressionsByDurationRanges(t *testing.T) {
 		{
 			name: "roundup_policy_valid_max_ads_more_than_max_ads",
 			args: args{
-				policy:        openrtb_ext.OWRoundupVideoLengthMatching,
+				policy:        openrtb_ext.OWRoundupVideoAdDurationMatching,
 				durations:     []int{5, 10, 15, 20, 25},
 				maxAds:        2,
 				adMinDuration: 10,

--- a/endpoints/openrtb2/ctv/impressions/by_duration_ranges.go
+++ b/endpoints/openrtb2/ctv/impressions/by_duration_ranges.go
@@ -7,16 +7,16 @@ import (
 
 // byDurRangeConfig struct will be used for creating impressions object based on list of duration ranges
 type byDurRangeConfig struct {
-	IImpressions                                          //IImpressions interface
-	policy        openrtb_ext.OWVideoLengthMatchingPolicy //duration matching algorithm round/exact
-	durations     []int                                   //durations list of durations in seconds used for creating impressions object
-	maxAds        int                                     //maxAds is number of max impressions can be created
-	adMinDuration int                                     //adpod slot mininum duration
-	adMaxDuration int                                     //adpod slot maximum duration
+	IImpressions                                              //IImpressions interface
+	policy        openrtb_ext.OWVideoAdDurationMatchingPolicy //duration matching algorithm round/exact
+	durations     []int                                       //durations list of durations in seconds used for creating impressions object
+	maxAds        int                                         //maxAds is number of max impressions can be created
+	adMinDuration int                                         //adpod slot mininum duration
+	adMaxDuration int                                         //adpod slot maximum duration
 }
 
 // newByDurationRanges will create new object ob byDurRangeConfig for creating impressions for adpod request
-func newByDurationRanges(policy openrtb_ext.OWVideoLengthMatchingPolicy, durations []int,
+func newByDurationRanges(policy openrtb_ext.OWVideoAdDurationMatchingPolicy, durations []int,
 	maxAds, adMinDuration, adMaxDuration int) byDurRangeConfig {
 
 	return byDurRangeConfig{
@@ -37,7 +37,7 @@ func (c *byDurRangeConfig) Get() [][2]int64 {
 		return make([][2]int64, 0)
 	}
 
-	isRoundupDurationMatchingPolicy := (openrtb_ext.OWRoundupVideoLengthMatching == c.policy)
+	isRoundupDurationMatchingPolicy := (openrtb_ext.OWRoundupVideoAdDurationMatching == c.policy)
 	var minDuration = -1
 	var validDurations []int
 

--- a/endpoints/openrtb2/ctv/impressions/impressions.go
+++ b/endpoints/openrtb2/ctv/impressions/impressions.go
@@ -71,7 +71,7 @@ func NewImpressions(podMinDuration, podMaxDuration int64, reqAdPod *openrtb_ext.
 	case ByDurationRanges:
 		util.Logf("Selected ImpGen Algorithm - 'ByDurationRanges'")
 
-		g := newByDurationRanges(reqAdPod.VideoLengthMatching, reqAdPod.VideoLengths,
+		g := newByDurationRanges(reqAdPod.VideoAdDurationMatching, reqAdPod.VideoAdDuration,
 			int(*vPod.MaxAds),
 			*vPod.MinDuration, *vPod.MaxDuration)
 
@@ -92,11 +92,11 @@ func NewImpressions(podMinDuration, podMaxDuration int64, reqAdPod *openrtb_ext.
 // SelectAlgorithm is factory function which will return valid Algorithm based on adpod parameters
 // Return Value:
 //   - MinMaxAlgorithm (default)
-//   - ByDurationRanges: if reqAdPod extension has VideoLengths and VideoLengthMatchingPolicy is "exact" algorithm
+//   - ByDurationRanges: if reqAdPod extension has VideoAdDuration and VideoAdDurationMatchingPolicy is "exact" algorithm
 func SelectAlgorithm(reqAdPod *openrtb_ext.ExtRequestAdPod) Algorithm {
 	if nil != reqAdPod {
-		if len(reqAdPod.VideoLengths) > 0 &&
-			(openrtb_ext.OWExactVideoLengthsMatching == reqAdPod.VideoLengthMatching || openrtb_ext.OWRoundupVideoLengthMatching == reqAdPod.VideoLengthMatching) {
+		if len(reqAdPod.VideoAdDuration) > 0 &&
+			(openrtb_ext.OWExactVideoAdDurationMatching == reqAdPod.VideoAdDurationMatching || openrtb_ext.OWRoundupVideoAdDurationMatching == reqAdPod.VideoAdDurationMatching) {
 			return ByDurationRanges
 		}
 	}

--- a/endpoints/openrtb2/ctv/impressions/impressions_test.go
+++ b/endpoints/openrtb2/ctv/impressions/impressions_test.go
@@ -25,23 +25,23 @@ func TestSelectAlgorithm(t *testing.T) {
 			want: MinMaxAlgorithm,
 		},
 		{
-			name: "missing_videolengths",
+			name: "missing_videoAdDuration",
 			args: args{reqAdPod: &openrtb_ext.ExtRequestAdPod{}},
 			want: MinMaxAlgorithm,
 		},
 		{
 			name: "roundup_matching_algo",
 			args: args{reqAdPod: &openrtb_ext.ExtRequestAdPod{
-				VideoLengths:        []int{15, 20},
-				VideoLengthMatching: openrtb_ext.OWRoundupVideoLengthMatching,
+				VideoAdDuration:         []int{15, 20},
+				VideoAdDurationMatching: openrtb_ext.OWRoundupVideoAdDurationMatching,
 			}},
 			want: ByDurationRanges,
 		},
 		{
 			name: "exact_matching_algo",
 			args: args{reqAdPod: &openrtb_ext.ExtRequestAdPod{
-				VideoLengths:        []int{15, 20},
-				VideoLengthMatching: openrtb_ext.OWExactVideoLengthsMatching,
+				VideoAdDuration:         []int{15, 20},
+				VideoAdDurationMatching: openrtb_ext.OWExactVideoAdDurationMatching,
 			}},
 			want: ByDurationRanges,
 		},
@@ -124,7 +124,7 @@ func TestNewImpressions(t *testing.T) {
 				podMinDuration: 15,
 				podMaxDuration: 90,
 				reqAdPod: &openrtb_ext.ExtRequestAdPod{
-					VideoLengths: []int{10, 15},
+					VideoAdDuration: []int{10, 15},
 				},
 				vPod: &openrtb_ext.VideoAdPod{
 					MinAds:      intPtr(1),

--- a/endpoints/openrtb2/ctv_auction.go
+++ b/endpoints/openrtb2/ctv_auction.go
@@ -1072,16 +1072,16 @@ func getAdPodBidExtension(adpod *types.AdPodBid) json.RawMessage {
 }
 
 // getDurationBasedOnDurationMatchingPolicy will return duration based on durationmatching policy
-func getDurationBasedOnDurationMatchingPolicy(duration int64, policy openrtb_ext.OWVideoLengthMatchingPolicy, config []*types.ImpAdPodConfig) (int64, constant.BidStatus) {
+func getDurationBasedOnDurationMatchingPolicy(duration int64, policy openrtb_ext.OWVideoAdDurationMatchingPolicy, config []*types.ImpAdPodConfig) (int64, constant.BidStatus) {
 	switch policy {
-	case openrtb_ext.OWExactVideoLengthsMatching:
+	case openrtb_ext.OWExactVideoAdDurationMatching:
 		tmp := util.GetNearestDuration(duration, config)
 		if tmp != duration {
 			return duration, constant.StatusDurationMismatch
 		}
 		//its and valid duration return it with StatusOK
 
-	case openrtb_ext.OWRoundupVideoLengthMatching:
+	case openrtb_ext.OWRoundupVideoAdDurationMatching:
 		tmp := util.GetNearestDuration(duration, config)
 		if tmp == -1 {
 			return duration, constant.StatusDurationMismatch
@@ -1110,8 +1110,8 @@ func getBidDuration(bid *openrtb2.Bid, reqExt *openrtb_ext.ExtRequestAdPod, conf
 	}
 
 	// C2: Based on video lengths matching policy validate and return duration
-	if nil != reqExt && len(reqExt.VideoLengthMatching) > 0 {
-		return getDurationBasedOnDurationMatchingPolicy(duration, reqExt.VideoLengthMatching, config)
+	if nil != reqExt && len(reqExt.VideoAdDurationMatching) > 0 {
+		return getDurationBasedOnDurationMatchingPolicy(duration, reqExt.VideoAdDurationMatching, config)
 	}
 
 	//default return duration which is present in bid.ext.prebid.vide.duration field

--- a/endpoints/openrtb2/ctv_auction_test.go
+++ b/endpoints/openrtb2/ctv_auction_test.go
@@ -377,7 +377,7 @@ func TestGetBidDuration(t *testing.T) {
 					Ext: json.RawMessage(`{"prebid":{"video":{"duration":30}}}`),
 				},
 				reqExt: &openrtb_ext.ExtRequestAdPod{
-					VideoLengthMatching: "",
+					VideoAdDurationMatching: "",
 				},
 				config:          nil,
 				defaultDuration: 100,
@@ -394,7 +394,7 @@ func TestGetBidDuration(t *testing.T) {
 					Ext: json.RawMessage(`{"prebid":{"video":{"duration":30}}}`),
 				},
 				reqExt: &openrtb_ext.ExtRequestAdPod{
-					VideoLengthMatching: openrtb_ext.OWExactVideoLengthsMatching,
+					VideoAdDurationMatching: openrtb_ext.OWExactVideoAdDurationMatching,
 				},
 				config: []*types.ImpAdPodConfig{
 					{MaxDuration: 10},
@@ -416,7 +416,7 @@ func TestGetBidDuration(t *testing.T) {
 					Ext: json.RawMessage(`{"prebid":{"video":{"duration":35}}}`),
 				},
 				reqExt: &openrtb_ext.ExtRequestAdPod{
-					VideoLengthMatching: openrtb_ext.OWExactVideoLengthsMatching,
+					VideoAdDurationMatching: openrtb_ext.OWExactVideoAdDurationMatching,
 				},
 				config: []*types.ImpAdPodConfig{
 					{MaxDuration: 10},
@@ -444,7 +444,7 @@ func TestGetBidDuration(t *testing.T) {
 func Test_getDurationBasedOnDurationMatchingPolicy(t *testing.T) {
 	type args struct {
 		duration int64
-		policy   openrtb_ext.OWVideoLengthMatchingPolicy
+		policy   openrtb_ext.OWVideoAdDurationMatchingPolicy
 		config   []*types.ImpAdPodConfig
 	}
 	type want struct {
@@ -477,7 +477,7 @@ func Test_getDurationBasedOnDurationMatchingPolicy(t *testing.T) {
 			name: "policy_exact",
 			args: args{
 				duration: 10,
-				policy:   openrtb_ext.OWExactVideoLengthsMatching,
+				policy:   openrtb_ext.OWExactVideoAdDurationMatching,
 				config: []*types.ImpAdPodConfig{
 					{MaxDuration: 10},
 					{MaxDuration: 20},
@@ -494,7 +494,7 @@ func Test_getDurationBasedOnDurationMatchingPolicy(t *testing.T) {
 			name: "policy_exact_didnot_match",
 			args: args{
 				duration: 15,
-				policy:   openrtb_ext.OWExactVideoLengthsMatching,
+				policy:   openrtb_ext.OWExactVideoAdDurationMatching,
 				config: []*types.ImpAdPodConfig{
 					{MaxDuration: 10},
 					{MaxDuration: 20},
@@ -511,7 +511,7 @@ func Test_getDurationBasedOnDurationMatchingPolicy(t *testing.T) {
 			name: "policy_roundup_exact",
 			args: args{
 				duration: 20,
-				policy:   openrtb_ext.OWRoundupVideoLengthMatching,
+				policy:   openrtb_ext.OWRoundupVideoAdDurationMatching,
 				config: []*types.ImpAdPodConfig{
 					{MaxDuration: 10},
 					{MaxDuration: 20},
@@ -528,7 +528,7 @@ func Test_getDurationBasedOnDurationMatchingPolicy(t *testing.T) {
 			name: "policy_roundup",
 			args: args{
 				duration: 25,
-				policy:   openrtb_ext.OWRoundupVideoLengthMatching,
+				policy:   openrtb_ext.OWRoundupVideoAdDurationMatching,
 				config: []*types.ImpAdPodConfig{
 					{MaxDuration: 10},
 					{MaxDuration: 20},
@@ -545,7 +545,7 @@ func Test_getDurationBasedOnDurationMatchingPolicy(t *testing.T) {
 			name: "policy_roundup_didnot_match",
 			args: args{
 				duration: 45,
-				policy:   openrtb_ext.OWRoundupVideoLengthMatching,
+				policy:   openrtb_ext.OWRoundupVideoAdDurationMatching,
 				config: []*types.ImpAdPodConfig{
 					{MaxDuration: 10},
 					{MaxDuration: 20},

--- a/openrtb_ext/adpod.go
+++ b/openrtb_ext/adpod.go
@@ -19,7 +19,7 @@ var (
 	errInvalidCrossPodIABCategoryExclusionPercent = errors.New("request.ext.adpod.crosspodexcliabcat must be a number between 0 and 100")
 	errInvalidIABCategoryExclusionWindow          = errors.New("request.ext.adpod.excliabcatwindow must be postive number")
 	errInvalidAdvertiserExclusionWindow           = errors.New("request.ext.adpod.excladvwindow must be postive number")
-	errInvalidVideoLengthMatching                 = errors.New("request.ext.adpod.videolengthmatching must be exact|roundup")
+	errInvalidVideoAdDurationMatching             = errors.New("request.ext.adpod.videoaddurationmatching must be exact|roundup")
 	errInvalidAdPodOffset                         = errors.New("request.imp.video.ext.offset must be postive number")
 	errInvalidMinAds                              = errors.New("%key%.ext.adpod.minads must be positive number")
 	errInvalidMaxAds                              = errors.New("%key%.ext.adpod.maxads must be positive number")
@@ -32,11 +32,11 @@ var (
 	errInvalidMinMaxDurationRange                 = errors.New("adpod duration checks for adminduration,admaxduration,minads,maxads are not in video minduration and maxduration duration range")
 )
 
-type OWVideoLengthMatchingPolicy = string
+type OWVideoAdDurationMatchingPolicy = string
 
 const (
-	OWExactVideoLengthsMatching  OWVideoLengthMatchingPolicy = `exact`
-	OWRoundupVideoLengthMatching OWVideoLengthMatchingPolicy = `roundup`
+	OWExactVideoAdDurationMatching   OWVideoAdDurationMatchingPolicy = `exact`
+	OWRoundupVideoAdDurationMatching OWVideoAdDurationMatchingPolicy = `roundup`
 )
 
 // ExtCTVBid defines the contract for bidresponse.seatbid.bid[i].ext
@@ -67,12 +67,12 @@ type ExtVideoAdPod struct {
 // ExtRequestAdPod holds AdPod specific extension parameters at request level
 type ExtRequestAdPod struct {
 	VideoAdPod
-	CrossPodAdvertiserExclusionPercent  *int                        `json:"crosspodexcladv,omitempty"`     //Percent Value - Across multiple impression there will be no ads from same advertiser. Note: These cross pod rule % values can not be more restrictive than per pod
-	CrossPodIABCategoryExclusionPercent *int                        `json:"crosspodexcliabcat,omitempty"`  //Percent Value - Across multiple impression there will be no ads from same advertiser
-	IABCategoryExclusionWindow          *int                        `json:"excliabcatwindow,omitempty"`    //Duration in minute between pods where exclusive IAB rule needs to be applied
-	AdvertiserExclusionWindow           *int                        `json:"excladvwindow,omitempty"`       //Duration in minute between pods where exclusive advertiser rule needs to be applied
-	VideoLengths                        []int                       `json:"videolengths,omitempty"`        //Range of ad durations allowed in the response
-	VideoLengthMatching                 OWVideoLengthMatchingPolicy `json:"videolengthmatching,omitempty"` //Flag indicating exact ad duration requirement. (default)empty/exact/round.
+	CrossPodAdvertiserExclusionPercent  *int                            `json:"crosspodexcladv,omitempty"`         //Percent Value - Across multiple impression there will be no ads from same advertiser. Note: These cross pod rule % values can not be more restrictive than per pod
+	CrossPodIABCategoryExclusionPercent *int                            `json:"crosspodexcliabcat,omitempty"`      //Percent Value - Across multiple impression there will be no ads from same advertiser
+	IABCategoryExclusionWindow          *int                            `json:"excliabcatwindow,omitempty"`        //Duration in minute between pods where exclusive IAB rule needs to be applied
+	AdvertiserExclusionWindow           *int                            `json:"excladvwindow,omitempty"`           //Duration in minute between pods where exclusive advertiser rule needs to be applied
+	VideoAdDuration                     []int                           `json:"VideoAdDuration,omitempty"`         //Range of ad durations allowed in the response
+	VideoAdDurationMatching             OWVideoAdDurationMatchingPolicy `json:"VideoAdDurationMatching,omitempty"` //Flag indicating exact ad duration requirement. (default)empty/exact/round.
 }
 
 // VideoAdPod holds Video AdPod specific extension parameters at impression level
@@ -171,8 +171,8 @@ func (ext *ExtRequestAdPod) Validate() (err []error) {
 		err = append(err, errInvalidAdvertiserExclusionWindow)
 	}
 
-	if len(ext.VideoLengthMatching) > 0 && !(OWExactVideoLengthsMatching == ext.VideoLengthMatching || OWRoundupVideoLengthMatching == ext.VideoLengthMatching) {
-		err = append(err, errInvalidVideoLengthMatching)
+	if len(ext.VideoAdDurationMatching) > 0 && !(OWExactVideoAdDurationMatching == ext.VideoAdDurationMatching || OWRoundupVideoAdDurationMatching == ext.VideoAdDurationMatching) {
+		err = append(err, errInvalidVideoAdDurationMatching)
 	}
 
 	if errL := ext.VideoAdPod.Validate(); nil != errL {

--- a/openrtb_ext/adpod_test.go
+++ b/openrtb_ext/adpod_test.go
@@ -158,7 +158,7 @@ func TestExtRequestAdPod_Validate(t *testing.T) {
 		CrossPodIABCategoryExclusionPercent *int
 		IABCategoryExclusionWindow          *int
 		AdvertiserExclusionWindow           *int
-		VideoLengthMatching                 string
+		VideoAdDurationMatching             string
 	}
 	tests := []struct {
 		name    string
@@ -208,11 +208,11 @@ func TestExtRequestAdPod_Validate(t *testing.T) {
 			wantErr: []error{errInvalidAdvertiserExclusionWindow},
 		},
 		{
-			name: "ErrInvalidVideoLengthMatching",
+			name: "ErrInvalidVideoAdDurationMatching",
 			fields: fields{
-				VideoLengthMatching: "invalid",
+				VideoAdDurationMatching: "invalid",
 			},
-			wantErr: []error{errInvalidVideoLengthMatching},
+			wantErr: []error{errInvalidVideoAdDurationMatching},
 		},
 		{
 			name: "InvalidAdPod",
@@ -251,7 +251,7 @@ func TestExtRequestAdPod_Validate(t *testing.T) {
 				CrossPodIABCategoryExclusionPercent: tt.fields.CrossPodIABCategoryExclusionPercent,
 				IABCategoryExclusionWindow:          tt.fields.IABCategoryExclusionWindow,
 				AdvertiserExclusionWindow:           tt.fields.AdvertiserExclusionWindow,
-				VideoLengthMatching:                 tt.fields.VideoLengthMatching,
+				VideoAdDurationMatching:             tt.fields.VideoAdDurationMatching,
 			}
 			actualErr := ext.Validate()
 			assert.Equal(t, tt.wantErr, actualErr)


### PR DESCRIPTION
# Description

This pr has change to rename adpod related configurations

 1) adPodsEnabled becomes adPodConfiguration
 2) videoLengths  becomes videoAdDuration
 3) videoLengthMatching  becomes videoAdDurationMatching

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
