### PR TITLE
UOE-8535: set pbs-go to owpbs-go in xprebidheader

### DIFF
--- a/endpoints/openrtb2/amp_auction_test.go
+++ b/endpoints/openrtb2/amp_auction_test.go
@@ -1517,7 +1517,7 @@ func TestAmpAuctionResponseHeaders(t *testing.T) {
 			expectedHeaders: func(h http.Header) {
 				h.Set("AMP-Access-Control-Allow-Source-Origin", "foo")
 				h.Set("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin")
-				h.Set("X-Prebid", "pbs-go/unknown")
+				h.Set("X-Prebid", "owpbs-go/unknown")
 				h.Set("Content-Type", "text/plain; charset=utf-8")
 			},
 		},
@@ -1528,7 +1528,7 @@ func TestAmpAuctionResponseHeaders(t *testing.T) {
 			expectedHeaders: func(h http.Header) {
 				h.Set("AMP-Access-Control-Allow-Source-Origin", "foo")
 				h.Set("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin")
-				h.Set("X-Prebid", "pbs-go/unknown")
+				h.Set("X-Prebid", "owpbs-go/unknown")
 			},
 		},
 	}

--- a/endpoints/openrtb2/auction_test.go
+++ b/endpoints/openrtb2/auction_test.go
@@ -3703,7 +3703,7 @@ func TestAuctionResponseHeaders(t *testing.T) {
 			requestBody:    validRequest(t, "site.json"),
 			expectedStatus: 200,
 			expectedHeaders: func(h http.Header) {
-				h.Set("X-Prebid", "pbs-go/unknown")
+				h.Set("X-Prebid", "owpbs-go/unknown")
 				h.Set("Content-Type", "application/json")
 			},
 		},
@@ -3712,7 +3712,7 @@ func TestAuctionResponseHeaders(t *testing.T) {
 			requestBody:    "{}",
 			expectedStatus: 400,
 			expectedHeaders: func(h http.Header) {
-				h.Set("X-Prebid", "pbs-go/unknown")
+				h.Set("X-Prebid", "owpbs-go/unknown")
 			},
 		},
 	}

--- a/endpoints/openrtb2/video_auction_test.go
+++ b/endpoints/openrtb2/video_auction_test.go
@@ -1185,7 +1185,7 @@ func TestVideoAuctionResponseHeaders(t *testing.T) {
 			givenTestFile:  "sample-requests/video/video_valid_sample.json",
 			expectedStatus: 200,
 			expectedHeaders: func(h http.Header) {
-				h.Set("X-Prebid", "pbs-go/unknown")
+				h.Set("X-Prebid", "owpbs-go/unknown")
 				h.Set("Content-Type", "application/json")
 			},
 		}, {
@@ -1193,7 +1193,7 @@ func TestVideoAuctionResponseHeaders(t *testing.T) {
 			givenTestFile:  "sample-requests/video/video_invalid_sample.json",
 			expectedStatus: 500,
 			expectedHeaders: func(h http.Header) {
-				h.Set("X-Prebid", "pbs-go/unknown")
+				h.Set("X-Prebid", "owpbs-go/unknown")
 			},
 		},
 	}

--- a/exchange/bidder_test.go
+++ b/exchange/bidder_test.go
@@ -334,7 +334,7 @@ func TestRequestBidRemovesSensitiveHeaders(t *testing.T) {
 		{
 			Uri:            server.URL,
 			RequestBody:    "requestJson",
-			RequestHeaders: map[string][]string{"Content-Type": {"application/json"}, "X-Prebid": {"pbs-go/test-version"}},
+			RequestHeaders: map[string][]string{"Content-Type": {"application/json"}, "X-Prebid": {"owpbs-go/test-version"}},
 			ResponseBody:   "responseJson",
 			Status:         200,
 		},
@@ -386,7 +386,7 @@ func TestSetGPCHeader(t *testing.T) {
 		{
 			Uri:            server.URL,
 			RequestBody:    "requestJson",
-			RequestHeaders: map[string][]string{"Content-Type": {"application/json"}, "X-Prebid": {"pbs-go/unknown"}, "Sec-Gpc": {"1"}},
+			RequestHeaders: map[string][]string{"Content-Type": {"application/json"}, "X-Prebid": {"owpbs-go/unknown"}, "Sec-Gpc": {"1"}},
 			ResponseBody:   "responseJson",
 			Status:         200,
 		},
@@ -436,7 +436,7 @@ func TestSetGPCHeaderNil(t *testing.T) {
 		{
 			Uri:            server.URL,
 			RequestBody:    "requestJson",
-			RequestHeaders: map[string][]string{"X-Prebid": {"pbs-go/unknown"}, "Sec-Gpc": {"1"}},
+			RequestHeaders: map[string][]string{"X-Prebid": {"owpbs-go/unknown"}, "Sec-Gpc": {"1"}},
 			ResponseBody:   "responseJson",
 			Status:         200,
 		},

--- a/version/xprebidheader.go
+++ b/version/xprebidheader.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prebid/prebid-server/openrtb_ext"
 )
 
-const xPrebidHeaderVersionPrefix = "pbs-go"
+const xPrebidHeaderVersionPrefix = "owpbs-go"
 
 func BuildXPrebidHeader(version string) string {
 	sb := &strings.Builder{}

--- a/version/xprebidheader_test.go
+++ b/version/xprebidheader_test.go
@@ -19,12 +19,12 @@ func TestBuildXPrebidHeader(t *testing.T) {
 		{
 			description: "No Version",
 			version:     "",
-			result:      "pbs-go/unknown",
+			result:      "owpbs-go/unknown",
 		},
 		{
 			description: "Version",
 			version:     "0.100.0",
-			result:      "pbs-go/0.100.0",
+			result:      "owpbs-go/0.100.0",
 		},
 	}
 
@@ -45,12 +45,12 @@ func TestBuildXPrebidHeaderForRequest(t *testing.T) {
 		{
 			description: "No versions",
 			version:     "",
-			result:      "pbs-go/unknown",
+			result:      "owpbs-go/unknown",
 		},
 		{
 			description: "pbs",
 			version:     "test-version",
-			result:      "pbs-go/test-version",
+			result:      "owpbs-go/test-version",
 		},
 		{
 			description: "prebid.js",
@@ -63,7 +63,7 @@ func TestBuildXPrebidHeaderForRequest(t *testing.T) {
 					},
 				},
 			},
-			result: "pbs-go/test-version,pbjs/test-pbjs-version",
+			result: "owpbs-go/test-version,pbjs/test-pbjs-version",
 		},
 		{
 			description: "unknown prebid.js",
@@ -75,7 +75,7 @@ func TestBuildXPrebidHeaderForRequest(t *testing.T) {
 					},
 				},
 			},
-			result: "pbs-go/test-version,pbjs/unknown",
+			result: "owpbs-go/test-version,pbjs/unknown",
 		},
 		{
 			description: "channel without a name",
@@ -87,7 +87,7 @@ func TestBuildXPrebidHeaderForRequest(t *testing.T) {
 					},
 				},
 			},
-			result: "pbs-go/test-version",
+			result: "owpbs-go/test-version",
 		},
 		{
 			description: "prebid-mobile",
@@ -98,7 +98,7 @@ func TestBuildXPrebidHeaderForRequest(t *testing.T) {
 					Version: "test-prebid-mobile-version",
 				},
 			},
-			result: "pbs-go/test-version,prebid-mobile/test-prebid-mobile-version",
+			result: "owpbs-go/test-version,prebid-mobile/test-prebid-mobile-version",
 		},
 		{
 			description: "app ext without a source",
@@ -108,7 +108,7 @@ func TestBuildXPrebidHeaderForRequest(t *testing.T) {
 					Version: "test-version",
 				},
 			},
-			result: "pbs-go/test-version",
+			result: "owpbs-go/test-version",
 		},
 		{
 			description: "Version found in both req.Ext and req.App.Ext",
@@ -127,7 +127,7 @@ func TestBuildXPrebidHeaderForRequest(t *testing.T) {
 					Version: "test-prebid-mobile-version",
 				},
 			},
-			result: "pbs-go/test-version,pbjs/test-pbjs-version,prebid-mobile/test-prebid-mobile-version",
+			result: "owpbs-go/test-version,pbjs/test-pbjs-version,prebid-mobile/test-prebid-mobile-version",
 		},
 	}
 


### PR DESCRIPTION
# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
