### PR TITLE
OTT-784: As a Header bidding module, I should be able to update wrapper logger object with rejected bids (both PSB and HB side) so that analytics team can consume it

### DIFF
--- a/analytics/core_ow.go
+++ b/analytics/core_ow.go
@@ -8,7 +8,7 @@ import (
 // RejectedBid contains oRTB Bid object with
 // rejection reason and seat information
 type RejectedBid struct {
-	RejectionReason openrtb3.LossReason
+	RejectionReason openrtb3.NonBidStatusCode
 	Bid             *openrtb2.Bid
 	Seat            string
 }

--- a/endpoints/openrtb2/auction_ow.go
+++ b/endpoints/openrtb2/auction_ow.go
@@ -13,7 +13,7 @@ func recordRejectedBids(pubID string, rejBids []analytics.RejectedBid, metricEng
 
 	var found bool
 	var codeLabel string
-	reasonCodeMap := make(map[openrtb3.LossReason]string)
+	reasonCodeMap := make(map[openrtb3.NonBidStatusCode]string)
 
 	for _, bid := range rejBids {
 		if codeLabel, found = reasonCodeMap[bid.RejectionReason]; !found {

--- a/endpoints/openrtb2/auction_ow_test.go
+++ b/endpoints/openrtb2/auction_ow_test.go
@@ -139,19 +139,19 @@ func TestRecordRejectedBids(t *testing.T) {
 				rejBids: []analytics.RejectedBid{
 					{
 						Seat:            "pubmatic",
-						RejectionReason: openrtb3.LossAdvertiserExclusions,
+						RejectionReason: openrtb3.LossBidAdvertiserExclusions,
 					},
 					{
 						Seat:            "pubmatic",
-						RejectionReason: openrtb3.LossBelowDealFloor,
+						RejectionReason: openrtb3.LossBidBelowDealFloor,
 					},
 					{
 						Seat:            "pubmatic",
-						RejectionReason: openrtb3.LossAdvertiserExclusions,
+						RejectionReason: openrtb3.LossBidAdvertiserExclusions,
 					},
 					{
 						Seat:            "appnexus",
-						RejectionReason: openrtb3.LossBelowDealFloor,
+						RejectionReason: openrtb3.LossBidBelowDealFloor,
 					},
 				},
 			},

--- a/endpoints/openrtb2/ctv_auction.go
+++ b/endpoints/openrtb2/ctv_auction.go
@@ -1104,7 +1104,7 @@ func adjustBidIDInVideoEventTrackers(doc *etree.Document, bid *openrtb2.Bid) {
 }
 
 func getRejectionReason(bidStatus int64) openrtb3.NonBidStatusCode {
-	var reason openrtb3.NonBidStatusCode
+	reason := openrtb3.NoBidWinningBid
 
 	switch bidStatus {
 	case constant.StatusOK:
@@ -1114,7 +1114,7 @@ func getRejectionReason(bidStatus int64) openrtb3.NonBidStatusCode {
 	case constant.StatusDomainExclusion:
 		reason = openrtb3.LossBidAdvertiserExclusions
 	case constant.StatusDurationMismatch:
-		reason = openrtb3.LossBidDurationMismatch
+		reason = openrtb3.LossBidInvalidCreative
 	}
 	return reason
 }

--- a/endpoints/openrtb2/ctv_auction.go
+++ b/endpoints/openrtb2/ctv_auction.go
@@ -1103,18 +1103,18 @@ func adjustBidIDInVideoEventTrackers(doc *etree.Document, bid *openrtb2.Bid) {
 	}
 }
 
-func getRejectionReason(bidStatus int64) openrtb3.LossReason {
-	reason := openrtb3.LossWon
+func getRejectionReason(bidStatus int64) openrtb3.NonBidStatusCode {
+	var reason openrtb3.NonBidStatusCode
 
 	switch bidStatus {
 	case constant.StatusOK:
-		reason = openrtb3.LossLostToHigherBid
+		reason = openrtb3.LossBidLostToHigherBid
 	case constant.StatusCategoryExclusion:
-		reason = openrtb3.LossCategoryExclusions
+		reason = openrtb3.LossBidCategoryExclusions
 	case constant.StatusDomainExclusion:
-		reason = openrtb3.LossAdvertiserExclusions
+		reason = openrtb3.LossBidAdvertiserExclusions
 	case constant.StatusDurationMismatch:
-		reason = openrtb3.LossCreativeFiltered
+		reason = openrtb3.LossBidDurationMismatch
 	}
 	return reason
 }

--- a/endpoints/openrtb2/ctv_auction_test.go
+++ b/endpoints/openrtb2/ctv_auction_test.go
@@ -813,7 +813,7 @@ func TestFilterRejectedBids(t *testing.T) {
 			want: want{
 				RejectedBids: []analytics.RejectedBid{
 					{
-						RejectionReason: openrtb3.LossLostToHigherBid,
+						RejectionReason: openrtb3.LossBidLostToHigherBid,
 						Seat:            "pubmatic",
 						Bid: &openrtb2.Bid{
 							ID:  "b2",
@@ -902,7 +902,7 @@ func TestFilterRejectedBids(t *testing.T) {
 			want: want{
 				RejectedBids: []analytics.RejectedBid{
 					{
-						RejectionReason: openrtb3.LossLostToHigherBid,
+						RejectionReason: openrtb3.LossBidLostToHigherBid,
 						Seat:            "pubmatic",
 						Bid: &openrtb2.Bid{
 							ID:  "b2",
@@ -910,7 +910,7 @@ func TestFilterRejectedBids(t *testing.T) {
 						},
 					},
 					{
-						RejectionReason: openrtb3.LossAdvertiserExclusions,
+						RejectionReason: openrtb3.LossBidAdvertiserExclusions,
 						Seat:            "appnexus",
 						Bid: &openrtb2.Bid{
 							ID:  "b3",

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -983,8 +983,8 @@ func applyCategoryMapping(ctx context.Context, r *AuctionRequest, requestExt *op
 					if r.LoggableObject != nil {
 						r.LoggableObject.RejectedBids = append(r.LoggableObject.RejectedBids, analytics.RejectedBid{
 							Bid:             bid.bid,
-							RejectionReason: openrtb3.LossBidCategoryExclusions,
-							Seat: seatBid.seat,
+							RejectionReason: openrtb3.LossBidCategoryMapping,
+							Seat:            seatBid.seat,
 						})
 					}
 				}
@@ -996,8 +996,8 @@ func applyCategoryMapping(ctx context.Context, r *AuctionRequest, requestExt *op
 					if r.LoggableObject != nil {
 						r.LoggableObject.RejectedBids = append(r.LoggableObject.RejectedBids, analytics.RejectedBid{
 							Bid:             bids[remInd].bid,
-							RejectionReason: openrtb3.LossBidCategoryExclusions,
-							Seat: seatBid.seat,
+							RejectionReason: openrtb3.LossBidCategoryMapping,
+							Seat:            seatBid.seat,
 						})
 					}
 					bids = append(bids[:remInd], bids[remInd+1:]...)

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -983,8 +983,8 @@ func applyCategoryMapping(ctx context.Context, r *AuctionRequest, requestExt *op
 					if r.LoggableObject != nil {
 						r.LoggableObject.RejectedBids = append(r.LoggableObject.RejectedBids, analytics.RejectedBid{
 							Bid:             bid.bid,
-							RejectionReason: openrtb3.LossCategoryExclusions,
-							Seat:            seatBid.seat,
+							RejectionReason: openrtb3.LossBidCategoryExclusions,
+							Seat: seatBid.seat,
 						})
 					}
 				}
@@ -996,8 +996,8 @@ func applyCategoryMapping(ctx context.Context, r *AuctionRequest, requestExt *op
 					if r.LoggableObject != nil {
 						r.LoggableObject.RejectedBids = append(r.LoggableObject.RejectedBids, analytics.RejectedBid{
 							Bid:             bids[remInd].bid,
-							RejectionReason: openrtb3.LossCategoryExclusions,
-							Seat:            seatBid.seat,
+							RejectionReason: openrtb3.LossBidCategoryExclusions,
+							Seat: seatBid.seat,
 						})
 					}
 					bids = append(bids[:remInd], bids[remInd+1:]...)

--- a/exchange/exchange_ow.go
+++ b/exchange/exchange_ow.go
@@ -108,7 +108,7 @@ func applyAdvertiserBlocking(r *AuctionRequest, seatBids map[openrtb_ext.BidderN
 						// Add rejectedBid for analytics logging.
 						if r.LoggableObject != nil {
 							r.LoggableObject.RejectedBids = append(r.LoggableObject.RejectedBids, analytics.RejectedBid{
-								RejectionReason: openrtb3.LossAdvertiserExclusions,
+								RejectionReason: openrtb3.LossBidAdvertiserBlocking,
 								Bid:             bid.bid,
 								Seat:            seatBid.seat,
 							})

--- a/exchange/exchange_ow_test.go
+++ b/exchange/exchange_ow_test.go
@@ -89,7 +89,7 @@ func TestApplyAdvertiserBlocking(t *testing.T) {
 			want: want{
 				expectedRejectedBids: []analytics.RejectedBid{
 					{
-						RejectionReason: openrtb3.LossAdvertiserExclusions,
+						RejectionReason: openrtb3.LossBidAdvertiserBlocking,
 						Bid: &openrtb2.Bid{
 							ID:      "a.com_bid",
 							ADomain: []string{"a.com"},
@@ -97,7 +97,7 @@ func TestApplyAdvertiserBlocking(t *testing.T) {
 						Seat: "",
 					},
 					{
-						RejectionReason: openrtb3.LossAdvertiserExclusions,
+						RejectionReason: openrtb3.LossBidAdvertiserBlocking,
 						Bid: &openrtb2.Bid{
 							ID:      "reject_b.a.com.a.com.b.c.d.a.com",
 							ADomain: []string{"b.a.com.a.com.b.c.d.a.com"},

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -2680,7 +2680,7 @@ func TestCategoryMappingTranslateCategoriesNil(t *testing.T) {
 	assert.Equal(t, "20.00_Sports_50s", bidCategory["bid_id2"], "Category mapping doesn't match")
 	assert.Equal(t, 2, len(adapterBids[bidderName1].bids), "Bidders number doesn't match")
 	assert.Equal(t, 2, len(bidCategory), "Bidders category mapping doesn't match")
-	assert.Equal(t, []analytics.RejectedBid{{Bid: &bid3, RejectionReason: openrtb3.LossBidCategoryExclusions}}, r.LoggableObject.RejectedBids, "Rejected Bids not matching")
+	assert.Equal(t, []analytics.RejectedBid{{Bid: &bid3, RejectionReason: openrtb3.LossBidCategoryMapping}}, r.LoggableObject.RejectedBids, "Rejected Bids not matching")
 }
 
 func newExtRequestTranslateCategories(translateCategories *bool) openrtb_ext.ExtRequest {
@@ -3114,7 +3114,7 @@ func TestBidRejectionErrors(t *testing.T) {
 			},
 			expectedRejectedBids: []analytics.RejectedBid{
 				{
-					RejectionReason: openrtb3.LossBidCategoryExclusions,
+					RejectionReason: openrtb3.LossBidCategoryMapping,
 					Bid:             &openrtb2.Bid{ID: "bid_id1", ImpID: "imp_id1", Price: 10.0000, Cat: []string{}, W: 1, H: 1},
 					Seat:            "",
 				},
@@ -3132,7 +3132,7 @@ func TestBidRejectionErrors(t *testing.T) {
 			},
 			expectedRejectedBids: []analytics.RejectedBid{
 				{
-					RejectionReason: openrtb3.LossBidCategoryExclusions,
+					RejectionReason: openrtb3.LossBidCategoryMapping,
 					Bid:             &openrtb2.Bid{ID: "bid_id1", ImpID: "imp_id1", Price: 10.0000, Cat: []string{"IAB1-1"}, W: 1, H: 1},
 					Seat:            "",
 				},
@@ -3150,7 +3150,7 @@ func TestBidRejectionErrors(t *testing.T) {
 			},
 			expectedRejectedBids: []analytics.RejectedBid{
 				{
-					RejectionReason: openrtb3.LossBidCategoryExclusions,
+					RejectionReason: openrtb3.LossBidCategoryMapping,
 					Bid:             &openrtb2.Bid{ID: "bid_id1", ImpID: "imp_id1", Price: 10.0000, Cat: []string{"IAB1-1"}, W: 1, H: 1},
 					Seat:            "",
 				},
@@ -3170,7 +3170,7 @@ func TestBidRejectionErrors(t *testing.T) {
 			expectedCatDur: "10.00_VideoGames_30s",
 			expectedRejectedBids: []analytics.RejectedBid{
 				{
-					RejectionReason: openrtb3.LossBidCategoryExclusions,
+					RejectionReason: openrtb3.LossBidCategoryMapping,
 					Bid:             &openrtb2.Bid{ID: "bid_id1", ImpID: "imp_id1", Price: 10.0000, Cat: []string{"IAB1-1"}, W: 1, H: 1},
 					Seat:            "",
 				},

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -2680,7 +2680,7 @@ func TestCategoryMappingTranslateCategoriesNil(t *testing.T) {
 	assert.Equal(t, "20.00_Sports_50s", bidCategory["bid_id2"], "Category mapping doesn't match")
 	assert.Equal(t, 2, len(adapterBids[bidderName1].bids), "Bidders number doesn't match")
 	assert.Equal(t, 2, len(bidCategory), "Bidders category mapping doesn't match")
-	assert.Equal(t, []analytics.RejectedBid{{Bid: &bid3, RejectionReason: openrtb3.LossCategoryExclusions}}, r.LoggableObject.RejectedBids, "Rejected Bids not matching")
+	assert.Equal(t, []analytics.RejectedBid{{Bid: &bid3, RejectionReason: openrtb3.LossBidCategoryExclusions}}, r.LoggableObject.RejectedBids, "Rejected Bids not matching")
 }
 
 func newExtRequestTranslateCategories(translateCategories *bool) openrtb_ext.ExtRequest {
@@ -3114,7 +3114,7 @@ func TestBidRejectionErrors(t *testing.T) {
 			},
 			expectedRejectedBids: []analytics.RejectedBid{
 				{
-					RejectionReason: openrtb3.LossCategoryExclusions,
+					RejectionReason: openrtb3.LossBidCategoryExclusions,
 					Bid:             &openrtb2.Bid{ID: "bid_id1", ImpID: "imp_id1", Price: 10.0000, Cat: []string{}, W: 1, H: 1},
 					Seat:            "",
 				},
@@ -3132,7 +3132,7 @@ func TestBidRejectionErrors(t *testing.T) {
 			},
 			expectedRejectedBids: []analytics.RejectedBid{
 				{
-					RejectionReason: openrtb3.LossCategoryExclusions,
+					RejectionReason: openrtb3.LossBidCategoryExclusions,
 					Bid:             &openrtb2.Bid{ID: "bid_id1", ImpID: "imp_id1", Price: 10.0000, Cat: []string{"IAB1-1"}, W: 1, H: 1},
 					Seat:            "",
 				},
@@ -3150,7 +3150,7 @@ func TestBidRejectionErrors(t *testing.T) {
 			},
 			expectedRejectedBids: []analytics.RejectedBid{
 				{
-					RejectionReason: openrtb3.LossCategoryExclusions,
+					RejectionReason: openrtb3.LossBidCategoryExclusions,
 					Bid:             &openrtb2.Bid{ID: "bid_id1", ImpID: "imp_id1", Price: 10.0000, Cat: []string{"IAB1-1"}, W: 1, H: 1},
 					Seat:            "",
 				},
@@ -3170,7 +3170,7 @@ func TestBidRejectionErrors(t *testing.T) {
 			expectedCatDur: "10.00_VideoGames_30s",
 			expectedRejectedBids: []analytics.RejectedBid{
 				{
-					RejectionReason: openrtb3.LossCategoryExclusions,
+					RejectionReason: openrtb3.LossBidCategoryExclusions,
 					Bid:             &openrtb2.Bid{ID: "bid_id1", ImpID: "imp_id1", Price: 10.0000, Cat: []string{"IAB1-1"}, W: 1, H: 1},
 					Seat:            "",
 				},

--- a/exchange/floors.go
+++ b/exchange/floors.go
@@ -81,9 +81,9 @@ func enforceFloorToBids(bidRequest *openrtb2.BidRequest, seatBids map[openrtb_ex
 							Bid:  bid.bid,
 							Seat: seatBid.seat,
 						}
-						rejectedBid.RejectionReason = openrtb3.LossBelowAuctionFloor
+						rejectedBid.RejectionReason = openrtb3.LossBidBelowAuctionFloor
 						if bid.bid.DealID != "" {
-							rejectedBid.RejectionReason = openrtb3.LossBelowDealFloor
+							rejectedBid.RejectionReason = openrtb3.LossBidBelowDealFloor
 						}
 						rejectedBids = append(rejectedBids, rejectedBid)
 						errs = append(errs, fmt.Errorf("bid rejected [bid ID: %s] reason: bid price value %.4f %s is less than bidFloor value %.4f %s for impression id %s bidder %s", bid.bid.ID, bidPrice, reqImpCur, reqImp.BidFloor, reqImpCur, bid.bid.ImpID, bidderName))

--- a/exchange/floors_test.go
+++ b/exchange/floors_test.go
@@ -965,7 +965,7 @@ func TestEnforceFloors(t *testing.T) {
 			want1: []string{"bid rejected [bid ID: some-bid-11] reason: bid price value 0.5000 USD is less than bidFloor value 20.0100 USD for impression id some-impression-id-1 bidder appnexus", "bid rejected [bid ID: some-bid-1] reason: bid price value 1.2000 USD is less than bidFloor value 20.0100 USD for impression id some-impression-id-1 bidder pubmatic"},
 			expectedRejectedBids: []analytics.RejectedBid{
 				{
-					RejectionReason: openrtb3.LossBelowDealFloor,
+					RejectionReason: openrtb3.LossBidBelowDealFloor,
 					Bid: &openrtb2.Bid{
 						ID:     "some-bid-11",
 						Price:  0.5,
@@ -975,7 +975,7 @@ func TestEnforceFloors(t *testing.T) {
 					Seat: "",
 				},
 				{
-					RejectionReason: openrtb3.LossBelowDealFloor,
+					RejectionReason: openrtb3.LossBidBelowDealFloor,
 					Bid: &openrtb2.Bid{
 						ID:     "some-bid-1",
 						Price:  1.2,
@@ -1060,7 +1060,7 @@ func TestEnforceFloors(t *testing.T) {
 			want1: []string{"bid rejected [bid ID: some-bid-11] reason: bid price value 0.5000 USD is less than bidFloor value 20.0100 USD for impression id some-impression-id-1 bidder appnexus"},
 			expectedRejectedBids: []analytics.RejectedBid{
 				{
-					RejectionReason: openrtb3.LossBelowAuctionFloor,
+					RejectionReason: openrtb3.LossBidBelowAuctionFloor,
 					Bid: &openrtb2.Bid{
 						ID:    "some-bid-11",
 						Price: 0.5,
@@ -1149,7 +1149,7 @@ func TestEnforceFloors(t *testing.T) {
 						Price: 0.5,
 						ImpID: "some-impression-id-1",
 					},
-					RejectionReason: openrtb3.LossBelowAuctionFloor,
+					RejectionReason: openrtb3.LossBidBelowAuctionFloor,
 					Seat:            "",
 				},
 			},
@@ -1228,7 +1228,7 @@ func TestEnforceFloors(t *testing.T) {
 			want1: []string{"bid rejected [bid ID: some-bid-11] reason: bid price value 0.5000 USD is less than bidFloor value 20.0100 USD for impression id some-impression-id-1 bidder appnexus"},
 			expectedRejectedBids: []analytics.RejectedBid{
 				{
-					RejectionReason: openrtb3.LossBelowAuctionFloor,
+					RejectionReason: openrtb3.LossBidBelowAuctionFloor,
 					Seat:            "",
 					Bid: &openrtb2.Bid{
 						ID:    "some-bid-11",
@@ -1311,7 +1311,7 @@ func TestEnforceFloors(t *testing.T) {
 			want1: []string{"bid rejected [bid ID: some-bid-11] reason: bid price value 0.5000 USD is less than bidFloor value 5.0100 USD for impression id some-impression-id-1 bidder appnexus"},
 			expectedRejectedBids: []analytics.RejectedBid{
 				{
-					RejectionReason: openrtb3.LossBelowAuctionFloor,
+					RejectionReason: openrtb3.LossBidBelowAuctionFloor,
 					Seat:            "",
 					Bid: &openrtb2.Bid{
 						ID:    "some-bid-11",
@@ -1719,7 +1719,7 @@ func TestEnforceFloors(t *testing.T) {
 						Price: 1.2,
 						ImpID: "some-impression-id-1",
 					},
-					RejectionReason: openrtb3.LossBelowAuctionFloor,
+					RejectionReason: openrtb3.LossBidBelowAuctionFloor,
 					Seat:            "",
 				}, {
 					Bid: &openrtb2.Bid{
@@ -1727,7 +1727,7 @@ func TestEnforceFloors(t *testing.T) {
 						Price: 0.5,
 						ImpID: "some-impression-id-1",
 					},
-					RejectionReason: openrtb3.LossBelowAuctionFloor,
+					RejectionReason: openrtb3.LossBidBelowAuctionFloor,
 					Seat:            "",
 				},
 			},

--- a/openrtb_ext/response.go
+++ b/openrtb_ext/response.go
@@ -99,9 +99,9 @@ type SeatNonBid struct {
 
 // NonBid defines the contract for bidresponse.ext.debug.seatnonbid.nonbid
 type NonBid struct {
-	ImpId      string           `json:"impid,omitempty"`
-	StatusCode NonBidStatusCode `json:"statuscode,omitempty"`
-	Ext        *ExtNonBid       `json:"ext,omitempty"`
+	ImpId      string                    `json:"impid,omitempty"`
+	StatusCode openrtb3.NonBidStatusCode `json:"statuscode,omitempty"`
+	Ext        *ExtNonBid                `json:"ext,omitempty"`
 }
 
 // ExtNonBid defines the contract for bidresponse.ext.debug.seatnonbid.nonbid.ext


### PR DESCRIPTION
# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
