### PR TITLE
UOE-8837: handle unmarshal error for imp.ext.{bidder} when imp.ext.tid is present

### DIFF
--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -3690,6 +3690,7 @@ func TestGetDealTiers(t *testing.T) {
 			},
 			expected: map[string]openrtb_ext.DealTierBidderMap{
 				"imp1": {openrtb_ext.BidderAppnexus: {Prefix: "tier1", MinDealTier: 5}},
+				"imp2": {},
 			},
 		},
 	}

--- a/openrtb_ext/deal_tier.go
+++ b/openrtb_ext/deal_tier.go
@@ -31,12 +31,11 @@ func ReadDealTiersFromImp(imp openrtb2.Imp) (DealTierBidderMap, error) {
 	var impExt map[string]struct {
 		DealTier *DealTier `json:"dealTier"`
 	}
-	if err := json.Unmarshal(imp.Ext, &impExt); err != nil {
-		return nil, err
-	}
-	for bidder, param := range impExt {
-		if param.DealTier != nil {
-			dealTiers[BidderName(bidder)] = *param.DealTier
+	if err := json.Unmarshal(imp.Ext, &impExt); err == nil {
+		for bidder, param := range impExt {
+			if param.DealTier != nil {
+				dealTiers[BidderName(bidder)] = *param.DealTier
+			}
 		}
 	}
 

--- a/openrtb_ext/deal_tier_test.go
+++ b/openrtb_ext/deal_tier_test.go
@@ -45,15 +45,25 @@ func TestReadDealTiersFromImp(t *testing.T) {
 			impExt:         json.RawMessage(`{"appnexus": {"placementId": 12345}}`),
 			expectedResult: DealTierBidderMap{},
 		},
-		{
-			description:   "imp.ext - error",
-			impExt:        json.RawMessage(`{"appnexus": {"dealTier": "wrong type", "placementId": 12345}}`),
-			expectedError: "json: cannot unmarshal string into Go struct field .dealTier of type openrtb_ext.DealTier",
-		},
+		// {
+		// 	description:   "imp.ext - error",
+		// 	impExt:        json.RawMessage(`{"appnexus": {"dealTier": "wrong type", "placementId": 12345}}`),
+		// 	expectedError: "json: cannot unmarshal string into Go struct field .dealTier of type openrtb_ext.DealTier",
+		// },
 		{
 			description:    "imp.ext.prebid",
 			impExt:         json.RawMessage(`{"prebid": {"bidder": {"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "anyPrefix"}, "placementId": 12345}}}}`),
 			expectedResult: DealTierBidderMap{BidderAppnexus: {Prefix: "anyPrefix", MinDealTier: 5}},
+		},
+		{
+			description:    "imp.ext.prebid - tid",
+			impExt:         json.RawMessage(`{"tid": "6f3998fa-811a-4732-a6bb-dbc37a1ca617", "prebid": {"bidder": {"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "anyPrefix"}, "placementId": 12345}}}}`),
+			expectedResult: DealTierBidderMap{BidderAppnexus: {Prefix: "anyPrefix", MinDealTier: 5}},
+		},
+		{
+			description:    "imp.ext - tid",
+			impExt:         json.RawMessage(`{"tid": "6f3998fa-811a-4732-a6bb-dbc37a1ca617", "appnexus": {"dealTier": {"minDealTier": 5, "prefix": "anyPrefix"}, "placementId": 12345}}`),
+			expectedResult: DealTierBidderMap{},
 		},
 		{
 			description:    "imp.ext.prebid- multiple",

--- a/openrtb_ext/deal_tier_test.go
+++ b/openrtb_ext/deal_tier_test.go
@@ -45,11 +45,11 @@ func TestReadDealTiersFromImp(t *testing.T) {
 			impExt:         json.RawMessage(`{"appnexus": {"placementId": 12345}}`),
 			expectedResult: DealTierBidderMap{},
 		},
-		// {
-		// 	description:   "imp.ext - error",
-		// 	impExt:        json.RawMessage(`{"appnexus": {"dealTier": "wrong type", "placementId": 12345}}`),
-		// 	expectedError: "json: cannot unmarshal string into Go struct field .dealTier of type openrtb_ext.DealTier",
-		// },
+		{
+			description:    "imp.ext - error",
+			impExt:         json.RawMessage(`{"appnexus": {"dealTier": "wrong type", "placementId": 12345}}`),
+			expectedResult: DealTierBidderMap{},
+		},
 		{
 			description:    "imp.ext.prebid",
 			impExt:         json.RawMessage(`{"prebid": {"bidder": {"appnexus": {"dealTier": {"minDealTier": 5, "prefix": "anyPrefix"}, "placementId": 12345}}}}`),


### PR DESCRIPTION
# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
