### PR TITLE
UOE-8988: update bidviewability datatype to generic

### DIFF
--- a/adapters/pubmatic/pubmatic.go
+++ b/adapters/pubmatic/pubmatic.go
@@ -383,7 +383,7 @@ func parseImpressionObject(imp *openrtb2.Imp, extractWrapperExtFromImp, extractP
 	}
 	// If bidViewabilityScore param is populated, pass it to imp[i].ext
 	if pubmaticExt.BidViewabilityScore != nil {
-		extMap[bidViewability] = *pubmaticExt.BidViewabilityScore
+		extMap[bidViewability] = pubmaticExt.BidViewabilityScore
 	}
 
 	imp.Ext = nil

--- a/adapters/pubmatic/pubmatic_test.go
+++ b/adapters/pubmatic/pubmatic_test.go
@@ -154,10 +154,10 @@ func TestParseImpressionObject(t *testing.T) {
 			args: args{
 				imp: &openrtb2.Imp{
 					Video: &openrtb2.Video{},
-					Ext:   json.RawMessage(`{"bidder":{"bidViewability":{"rendered":131,"viewed":80,"createdAt":1666155076240,"updatedAt":1666296333802,"lastViewed":3171.100000023842,"totalViewTime":15468}}}`),
+					Ext:   json.RawMessage(`{"bidder":{"bidViewability":{"adSizes":{"728x90":{"createdAt":1679993940011,"rendered":20,"totalViewTime":424413,"viewed":17}},"adUnit":{"createdAt":1679993940011,"rendered":25,"totalViewTime":424413,"viewed":17}}}}`),
 				},
 			},
-			expectedImpExt: json.RawMessage(`{"bidViewability":{"rendered":131,"viewed":80,"createdAt":1666155076240,"updatedAt":1666296333802,"lastViewed":3171.100000023842,"totalViewTime":15468}}`),
+			expectedImpExt: json.RawMessage(`{"bidViewability":{"adSizes":{"728x90":{"createdAt":1679993940011,"rendered":20,"totalViewTime":424413,"viewed":17}},"adUnit":{"createdAt":1679993940011,"rendered":25,"totalViewTime":424413,"viewed":17}}}`),
 		},
 	}
 	for _, tt := range tests {

--- a/openrtb_ext/imp_pubmatic.go
+++ b/openrtb_ext/imp_pubmatic.go
@@ -16,21 +16,11 @@ type ExtImpPubmatic struct {
 	WrapExt             json.RawMessage         `json:"wrapper,omitempty"`
 	Keywords            []*ExtImpPubmaticKeyVal `json:"keywords,omitempty"`
 	Kadfloor            string                  `json:"kadfloor,omitempty"`
-	BidViewabilityScore *ExtBidViewabilityScore `json:"bidViewability,omitempty"`
+	BidViewabilityScore map[string]interface{}  `json:"bidViewability,omitempty"`
 }
 
 // ExtImpPubmaticKeyVal defines the contract for bidrequest.imp[i].ext.prebid.bidder.pubmatic.keywords[i]
 type ExtImpPubmaticKeyVal struct {
 	Key    string   `json:"key,omitempty"`
 	Values []string `json:"value,omitempty"`
-}
-
-// ExtBidViewabilityScore defines the contract for bidrequest.imp[i].ext.pubmatic.bidViewability
-type ExtBidViewabilityScore struct {
-	Rendered      int     `json:"rendered,omitempty"`
-	Viewed        int     `json:"viewed,omitempty"`
-	CreatedAt     int     `json:"createdAt,omitempty"`
-	UpdatedAt     int     `json:"updatedAt,omitempty"`
-	LastViewed    float64 `json:"lastViewed,omitempty"`
-	TotalViewTime float64 `json:"totalViewTime,omitempty"`
 }


### PR DESCRIPTION
[UOE-8902] - As per Changes in the Bidviewability structure, removing the adapter level checks for viewability data