### PR TITLE
UOE-9443: handle missing 'default' adunitconfig

### DIFF
--- a/modules/pubmatic/openwrap/database/mysql/adunit_config.go
+++ b/modules/pubmatic/openwrap/database/mysql/adunit_config.go
@@ -39,5 +39,10 @@ func (db *mySqlDB) GetAdunitConfig(profileID, displayVersion int) (*adunitconfig
 		//Default configPattern value is "_AU_" if not present in db config
 		adunitConfig.ConfigPattern = models.MACRO_AD_UNIT_ID
 	}
+
+	if _, ok := adunitConfig.Config["default"]; !ok {
+		adunitConfig.Config["default"] = &adunitconfig.AdConfig{}
+	}
+
 	return adunitConfig, err
 }

--- a/modules/pubmatic/openwrap/database/mysql/adunit_config_test.go
+++ b/modules/pubmatic/openwrap/database/mysql/adunit_config_test.go
@@ -155,6 +155,37 @@ func Test_mySqlDB_GetAdunitConfig(t *testing.T) {
 				return db
 			},
 		},
+		{
+			name: "default adunit not present",
+			fields: fields{
+				cfg: config.Database{
+					Queries: config.Queries{
+						GetAdunitConfigQuery: "^SELECT (.+) FROM wrapper_media_config (.+)",
+					},
+				},
+			},
+			args: args{
+				profileID:      5890,
+				displayVersion: 1,
+			},
+			want: &adunitconfig.AdUnitConfig{
+				ConfigPattern: "_DIV_",
+				Config: map[string]*adunitconfig.AdConfig{
+					"default": {},
+					"abc":     {BidFloor: ptrutil.ToPtr(3.1)},
+				},
+			},
+			wantErr: false,
+			setup: func() *sql.DB {
+				db, mock, err := sqlmock.New()
+				if err != nil {
+					t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+				}
+				rows := sqlmock.NewRows([]string{"adunitConfig"}).AddRow(`{"configPattern": "_DIV_", "config":{"abc":{"bidfloor":3.1}}}`)
+				mock.ExpectQuery(regexp.QuoteMeta("^SELECT (.+) FROM wrapper_media_config (.+)")).WillReturnRows(rows)
+				return db
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
