### PR TITLE
OTT-1297: fix: do not log error stats for profiles w/o adunitconfig

### DIFF
--- a/modules/pubmatic/openwrap/database/mysql/adunit_config.go
+++ b/modules/pubmatic/openwrap/database/mysql/adunit_config.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"database/sql"
 	"encoding/json"
 	"strconv"
 	"strings"
@@ -21,6 +22,9 @@ func (db *mySqlDB) GetAdunitConfig(profileID, displayVersion int) (*adunitconfig
 	var adunitConfigJSON string
 	err := db.conn.QueryRow(adunitConfigQuery).Scan(&adunitConfigJSON)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/modules/pubmatic/openwrap/database/mysql/adunit_config_test.go
+++ b/modules/pubmatic/openwrap/database/mysql/adunit_config_test.go
@@ -41,6 +41,31 @@ func Test_mySqlDB_GetAdunitConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "adunitconfig not found for profile(No rows error)",
+			fields: fields{
+				cfg: config.Database{
+					Queries: config.Queries{
+						GetAdunitConfigForLiveVersion: "^SELECT (.+) FROM wrapper_media_config (.+) LIVE",
+					},
+				},
+			},
+			args: args{
+				profileID:      5890,
+				displayVersion: 0,
+			},
+			want:    nil,
+			wantErr: false,
+			setup: func() *sql.DB {
+				db, mock, err := sqlmock.New()
+				if err != nil {
+					t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+				}
+				rows := sqlmock.NewRows([]string{})
+				mock.ExpectQuery(regexp.QuoteMeta("^SELECT (.+) FROM wrapper_media_config (.+) LIVE")).WillReturnRows(rows)
+				return db
+			},
+		},
+		{
 			name: "query with display version id 0",
 			fields: fields{
 				cfg: config.Database{


### PR DESCRIPTION
# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
