### PR TITLE
OTT-1319: add prometheus stats to count number of bids with vast unwrapped

### DIFF
--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -261,7 +261,7 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest Bidde
 			errs = append(errs, moreErrs...)
 
 			if bidResponse != nil {
-				recordVastTag(bidder.me, bidResponse, bidder.BidderName)
+				recordVASTTagType(bidder.me, bidResponse, bidder.BidderName)
 				reject := hookExecutor.ExecuteRawBidderResponseStage(bidResponse, string(bidder.BidderName))
 				if reject != nil {
 					errs = append(errs, reject)

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -261,7 +261,7 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest Bidde
 			errs = append(errs, moreErrs...)
 
 			if bidResponse != nil {
-				recordVastTag(bidder.me, bidResponse)
+				recordVastTag(bidder.me, bidResponse, bidder.BidderName)
 				reject := hookExecutor.ExecuteRawBidderResponseStage(bidResponse, string(bidder.BidderName))
 				if reject != nil {
 					errs = append(errs, reject)

--- a/exchange/bidder.go
+++ b/exchange/bidder.go
@@ -261,6 +261,7 @@ func (bidder *bidderAdapter) requestBid(ctx context.Context, bidderRequest Bidde
 			errs = append(errs, moreErrs...)
 
 			if bidResponse != nil {
+				recordVastTag(bidder.me, bidResponse)
 				reject := hookExecutor.ExecuteRawBidderResponseStage(bidResponse, string(bidder.BidderName))
 				if reject != nil {
 					errs = append(errs, reject)

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -394,7 +394,6 @@ func (e *exchange) HoldAuction(ctx context.Context, r *AuctionRequest, debugLog 
 	if anyBidsReturned {
 		recordBids(ctx, e.me, r.PubID, adapterBids)
 		recordVastVersion(e.me, adapterBids)
-		recordVastTag(e.me, adapterBids)
 
 		if e.floor.Enabled {
 			var rejectedBids []*entities.PbsOrtbSeatBid

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -394,6 +394,7 @@ func (e *exchange) HoldAuction(ctx context.Context, r *AuctionRequest, debugLog 
 	if anyBidsReturned {
 		recordBids(ctx, e.me, r.PubID, adapterBids)
 		recordVastVersion(e.me, adapterBids)
+		recordVastTag(e.me, adapterBids)
 
 		if e.floor.Enabled {
 			var rejectedBids []*entities.PbsOrtbSeatBid

--- a/exchange/exchange_ow.go
+++ b/exchange/exchange_ow.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/prebid/openrtb/v19/openrtb2"
 	"github.com/prebid/openrtb/v19/openrtb3"
+	"github.com/prebid/prebid-server/adapters"
 	"github.com/prebid/prebid-server/exchange/entities"
 	"github.com/prebid/prebid-server/metrics"
 	pubmaticstats "github.com/prebid/prebid-server/metrics/pubmatic_stats"
@@ -183,18 +184,18 @@ func recordVastVersion(metricsEngine metrics.MetricsEngine, adapterBids map[open
 	}
 }
 
-func recordVastTag(metricsEngine metrics.MetricsEngine, adapterBids map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid) {
+func recordVastTag(metricsEngine metrics.MetricsEngine, adapterBids *adapters.BidderResponse) {
 	vastTag := Unknown
-	for _, adapterBid := range adapterBids {
-		for _, bid := range adapterBid.Bids {
-			if strings.Contains(bid.Bid.AdM, WrapperElement) {
+	for _, adapterBid := range adapterBids.Bids {
+		if adapterBid.BidType == openrtb_ext.BidTypeVideo {
+			if strings.Contains(adapterBid.Bid.AdM, WrapperElement) {
 				vastTag = Wrapper
-			} else if strings.Contains(bid.Bid.AdM, InlineElement) {
+			} else if strings.Contains(adapterBid.Bid.AdM, InlineElement) {
 				vastTag = Inline
-			} else if IsUrl(bid.Bid.AdM) {
+			} else if IsUrl(adapterBid.Bid.AdM) {
 				vastTag = URL
 			}
-			metricsEngine.RecordVastTag(string(adapterBid.BidderCoreName), vastTag)
+			metricsEngine.RecordVastTag(string(adapterBid.Seat), vastTag)
 		}
 	}
 }

--- a/exchange/exchange_ow.go
+++ b/exchange/exchange_ow.go
@@ -31,10 +31,6 @@ const (
 const (
 	VASTTypeWrapperEndTag = "</Wrapper>"
 	VASTTypeInLineEndTag  = "</InLine>"
-	Wrapper               = "Wrapper"
-	Inline                = "InLine"
-	URL                   = "URL"
-	Unknown               = "Unknown"
 )
 
 // VASTTagType describes the allowed values for VASTTagType

--- a/exchange/exchange_ow.go
+++ b/exchange/exchange_ow.go
@@ -29,12 +29,22 @@ const (
 )
 
 const (
-	WrapperElement = "<Wrapper>"
-	InlineElement  = "<InLine>"
-	Wrapper        = "Wrapper"
-	Inline         = "InLine"
-	URL            = "URL"
-	Unknown        = "Unknown"
+	VASTTypeWrapperEndTag = "</Wrapper>"
+	VASTTypeInLineEndTag  = "</InLine>"
+	Wrapper               = "Wrapper"
+	Inline                = "InLine"
+	URL                   = "URL"
+	Unknown               = "Unknown"
+)
+
+// VASTTagType describes the allowed values for VASTTagType
+type VASTTagType string
+
+const (
+	WrapperVASTTagType VASTTagType = "Wrapper"
+	InLineVASTTagType  VASTTagType = "InLine"
+	URLVASTTagType     VASTTagType = "URL"
+	UnknownVASTTagType VASTTagType = "Unknown"
 )
 
 var (
@@ -184,18 +194,18 @@ func recordVastVersion(metricsEngine metrics.MetricsEngine, adapterBids map[open
 	}
 }
 
-func recordVastTag(metricsEngine metrics.MetricsEngine, adapterBids *adapters.BidderResponse, bidder openrtb_ext.BidderName) {
-	vastTag := Unknown
+func recordVASTTagType(metricsEngine metrics.MetricsEngine, adapterBids *adapters.BidderResponse, bidder openrtb_ext.BidderName) {
+	vastTagType := UnknownVASTTagType
 	for _, adapterBid := range adapterBids.Bids {
 		if adapterBid.BidType == openrtb_ext.BidTypeVideo {
-			if strings.Contains(adapterBid.Bid.AdM, WrapperElement) {
-				vastTag = Wrapper
-			} else if strings.Contains(adapterBid.Bid.AdM, InlineElement) {
-				vastTag = Inline
+			if index := strings.LastIndex(adapterBid.Bid.AdM, VASTTypeWrapperEndTag); index != -1 {
+				vastTagType = WrapperVASTTagType
+			} else if index := strings.LastIndex(adapterBid.Bid.AdM, VASTTypeInLineEndTag); index != -1 {
+				vastTagType = InLineVASTTagType
 			} else if IsUrl(adapterBid.Bid.AdM) {
-				vastTag = URL
+				vastTagType = URLVASTTagType
 			}
-			metricsEngine.RecordVastTag(string(bidder), vastTag)
+			metricsEngine.RecordVASTTagType(string(bidder), string(vastTagType))
 		}
 	}
 }

--- a/exchange/exchange_ow.go
+++ b/exchange/exchange_ow.go
@@ -184,7 +184,7 @@ func recordVastVersion(metricsEngine metrics.MetricsEngine, adapterBids map[open
 	}
 }
 
-func recordVastTag(metricsEngine metrics.MetricsEngine, adapterBids *adapters.BidderResponse) {
+func recordVastTag(metricsEngine metrics.MetricsEngine, adapterBids *adapters.BidderResponse, bidder openrtb_ext.BidderName) {
 	vastTag := Unknown
 	for _, adapterBid := range adapterBids.Bids {
 		if adapterBid.BidType == openrtb_ext.BidTypeVideo {
@@ -195,7 +195,7 @@ func recordVastTag(metricsEngine metrics.MetricsEngine, adapterBids *adapters.Bi
 			} else if IsUrl(adapterBid.Bid.AdM) {
 				vastTag = URL
 			}
-			metricsEngine.RecordVastTag(string(adapterBid.Seat), vastTag)
+			metricsEngine.RecordVastTag(string(bidder), vastTag)
 		}
 	}
 }

--- a/exchange/exchange_ow.go
+++ b/exchange/exchange_ow.go
@@ -195,9 +195,9 @@ func recordVastVersion(metricsEngine metrics.MetricsEngine, adapterBids map[open
 }
 
 func recordVASTTagType(metricsEngine metrics.MetricsEngine, adapterBids *adapters.BidderResponse, bidder openrtb_ext.BidderName) {
-	vastTagType := UnknownVASTTagType
 	for _, adapterBid := range adapterBids.Bids {
 		if adapterBid.BidType == openrtb_ext.BidTypeVideo {
+			vastTagType := UnknownVASTTagType
 			if index := strings.LastIndex(adapterBid.Bid.AdM, VASTTypeWrapperEndTag); index != -1 {
 				vastTagType = WrapperVASTTagType
 			} else if index := strings.LastIndex(adapterBid.Bid.AdM, VASTTypeInLineEndTag); index != -1 {

--- a/exchange/exchange_ow_test.go
+++ b/exchange/exchange_ow_test.go
@@ -1777,7 +1777,7 @@ func TestRecordVastTag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockMetricEngine := tt.args.getMetricsEngine()
-			recordVastTag(mockMetricEngine, tt.args.adapterBids)
+			recordVastTag(mockMetricEngine, tt.args.adapterBids, "pubmatic")
 			mockMetricEngine.AssertExpectations(t)
 		})
 	}

--- a/exchange/exchange_ow_test.go
+++ b/exchange/exchange_ow_test.go
@@ -23,6 +23,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var vastXMLAdM = "<VAST version='3.0'><Ad id='1'><Wrapper><AdSystem>PubMatic</AdSystem><VASTAdTagURI><![CDATA[https://owsdk-stagingams.pubmatic.com:8443/openwrap/video/Shashank/dspResponse/vastInline.php?m=1&x=3&y=3&p=11&va=3&sc=1]]></VASTAdTagURI><Error><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&er=[ERRORCODE]]]></Error><Impression><![CDATA[https://aktrack.pubmatic.com/AdServer/AdDisplayTrackerServlet?operId=1&pubId=64195&siteId=47105&adId=1405154&adType=13&adServerId=243&kefact=1.000000&kaxefact=1.000000&kadNetFrequecy=0&kadwidth=0&kadheight=0&kadsizeid=97&kltstamp=1536933242&indirectAdId=0&adServerOptimizerId=2&ranreq=0.05969169352174375&kpbmtpfact=11.000000&dcId=1&tldId=0&passback=0&svr=ktk57&ekefact=er2bW2sDAwCra06ACbsIQySn5nqBtYsTl8fy5lupAexh37D_&ekaxefact=er2bW4EDAwB_LQpJJ23Fq0DcNC-NSAFXdpSQC8XBk_S33_Fa&ekpbmtpfact=er2bW5MDAwDJHdBnLBt5IrRuh7x0oqp_tjIALv_VvSQDAl6R&crID=m:1_x:3_y:3_p:11_va:3&lpu=ae.com&ucrid=678722001014421372&campaignId=16774&creativeId=0&pctr=0.000000&wDSPByrId=511&wDspId=27&wbId=0&wrId=0&wAdvID=3170&isRTB=1&rtbId=EBCA079F-8D7C-45B8-B733-92951F670AA1&imprId=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&oid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&pageURL=http%253A%252F%252Fowsdk-stagingams.pubmatic.com%253A8443%252Fvast-validator%252F%2523&sec=1&pmc=1]]></Impression><Creatives><Creative><Linear><TrackingEvents><Tracking event='creativeView'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=1]]></Tracking><Tracking event='start'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=2]]></Tracking><Tracking event='midpoint'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=3]]></Tracking><Tracking event='firstQuartile'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=4]]></Tracking><Tracking event='thirdQuartile'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=5]]></Tracking><Tracking event='complete'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=6]]></Tracking></TrackingEvents><VideoClicks><ClickTracking><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=99]]></ClickTracking></VideoClicks></Linear></Creative><Creative><NonLinearAds><TrackingEvents><Tracking event='creativeView'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=1]]></Tracking><Tracking event='start'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=2]]></Tracking><Tracking event='midpoint'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=3]]></Tracking><Tracking event='firstQuartile'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=4]]></Tracking><Tracking event='thirdQuartile'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=5]]></Tracking><Tracking event='complete'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=6]]></Tracking></TrackingEvents></NonLinearAds></Creative></Creatives></Wrapper></Ad></VAST>"
+var inlineXMLAdM = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?><VAST version=\"3.0\"><Ad id=\"1329167\"><InLine><AdSystem>Acudeo Compatible</AdSystem><AdTitle>VAST 2.0 Instream Test 1</AdTitle><Description>VAST 2.0 Instream Test 1</Description><Error>https://aktrack.pubmatic.com/track?operId=7&amp;p=64195&amp;s=47105&amp;a=1405154&amp;wa=243&amp;ts=1536933242&amp;wc=16774&amp;crId=m:1_x:3_y:3_p:11_va:3&amp;ucrid=678722001014421372&amp;impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;advertiser_id=3170&amp;ecpm=1.000000&amp;er=[ERRORCODE]</Error><Error>https://track.dsptracker.com?p=1234&amp;er=[ERRORCODE]</Error><Impression>https://aktrack.pubmatic.com/AdServer/AdDisplayTrackerServlet?operId=1&amp;pubId=64195&amp;siteId=47105&amp;adId=1405154&amp;adType=13&amp;adServerId=243&amp;kefact=1.000000&amp;kaxefact=1.000000&amp;kadNetFrequecy=0&amp;kadwidth=0&amp;kadheight=0&amp;kadsizeid=97&amp;kltstamp=1536933242&amp;indirectAdId=0&amp;adServerOptimizerId=2&amp;ranreq=0.05969169352174375&amp;kpbmtpfact=11.000000&amp;dcId=1&amp;tldId=0&amp;passback=0&amp;svr=ktk57&amp;ekefact=er2bW2sDAwCra06ACbsIQySn5nqBtYsTl8fy5lupAexh37D_&amp;ekaxefact=er2bW4EDAwB_LQpJJ23Fq0DcNC-NSAFXdpSQC8XBk_S33_Fa&amp;ekpbmtpfact=er2bW5MDAwDJHdBnLBt5IrRuh7x0oqp_tjIALv_VvSQDAl6R&amp;crID=m:1_x:3_y:3_p:11_va:3&amp;lpu=ae.com&amp;ucrid=678722001014421372&amp;campaignId=16774&amp;creativeId=0&amp;pctr=0.000000&amp;wDSPByrId=511&amp;wDspId=27&amp;wbId=0&amp;wrId=0&amp;wAdvID=3170&amp;isRTB=1&amp;rtbId=EBCA079F-8D7C-45B8-B733-92951F670AA1&amp;imprId=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;oid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;pageURL=http%253A%252F%252Fowsdk-stagingams.pubmatic.com%253A8443%252Fvast-validator%252F%2523&amp;sec=1&amp;pmc=1</Impression><Impression>https://DspImpressionTracker.com/</Impression><Creatives><Creative AdID=\"1329167\"><Linear skipoffset=\"20%\"><TrackingEvents><Tracking event=\"close\">https://mytracking.com/linear/close</Tracking><Tracking event=\"skip\">https://mytracking.com/linear/skip</Tracking><Tracking event=\"creativeView\">https://aktrack.pubmatic.com/track?operId=7&amp;p=64195&amp;s=47105&amp;a=1405154&amp;wa=243&amp;ts=1536933242&amp;wc=16774&amp;crId=m:1_x:3_y:3_p:11_va:3&amp;ucrid=678722001014421372&amp;impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;advertiser_id=3170&amp;ecpm=1.000000&amp;e=1</Tracking><Tracking event=\"start\">https://aktrack.pubmatic.com/track?operId=7&amp;p=64195&amp;s=47105&amp;a=1405154&amp;wa=243&amp;ts=1536933242&amp;wc=16774&amp;crId=m:1_x:3_y:3_p:11_va:3&amp;ucrid=678722001014421372&amp;impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;advertiser_id=3170&amp;ecpm=1.000000&amp;e=2</Tracking><Tracking event=\"midpoint\">https://aktrack.pubmatic.com/track?operId=7&amp;p=64195&amp;s=47105&amp;a=1405154&amp;wa=243&amp;ts=1536933242&amp;wc=16774&amp;crId=m:1_x:3_y:3_p:11_va:3&amp;ucrid=678722001014421372&amp;impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;advertiser_id=3170&amp;ecpm=1.000000&amp;e=3</Tracking><Tracking event=\"firstQuartile\">https://aktrack.pubmatic.com/track?operId=7&amp;p=64195&amp;s=47105&amp;a=1405154&amp;wa=243&amp;ts=1536933242&amp;wc=16774&amp;crId=m:1_x:3_y:3_p:11_va:3&amp;ucrid=678722001014421372&amp;impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;advertiser_id=3170&amp;ecpm=1.000000&amp;e=4</Tracking><Tracking event=\"thirdQuartile\">https://aktrack.pubmatic.com/track?operId=7&amp;p=64195&amp;s=47105&amp;a=1405154&amp;wa=243&amp;ts=1536933242&amp;wc=16774&amp;crId=m:1_x:3_y:3_p:11_va:3&amp;ucrid=678722001014421372&amp;impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;advertiser_id=3170&amp;ecpm=1.000000&amp;e=5</Tracking><Tracking event=\"complete\">https://aktrack.pubmatic.com/track?operId=7&amp;p=64195&amp;s=47105&amp;a=1405154&amp;wa=243&amp;ts=1536933242&amp;wc=16774&amp;crId=m:1_x:3_y:3_p:11_va:3&amp;ucrid=678722001014421372&amp;impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;advertiser_id=3170&amp;ecpm=1.000000&amp;e=6</Tracking></TrackingEvents><Duration>00:00:04</Duration><VideoClicks><ClickThrough>https://www.automationtester.in</ClickThrough><ClickTracking>https://aktrack.pubmatic.com/track?operId=7&amp;p=64195&amp;s=47105&amp;a=1405154&amp;wa=243&amp;ts=1536933242&amp;wc=16774&amp;crId=m:1_x:3_y:3_p:11_va:3&amp;ucrid=678722001014421372&amp;impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;advertiser_id=3170&amp;ecpm=1.000000&amp;e=99</ClickTracking></VideoClicks><MediaFiles><MediaFile delivery=\"progressive\" type=\"video/mp4\" bitrate=\"500\" width=\"400\" height=\"300\" scalable=\"true\" maintainAspectRatio=\"true\">https://stagingams.pubmatic.com:8443/openwrap/media/pubmatic.mp4</MediaFile><MediaFile delivery=\"progressive\" type=\"video/mp4\" bitrate=\"500\" width=\"400\" height=\"300\" scalable=\"true\" maintainAspectRatio=\"true\">https://stagingams.pubmatic.com:8443/openwrap/media/pubmatic.mp4</MediaFile><MediaFile delivery=\"progressive\" type=\"video/mp4\" bitrate=\"500\" width=\"400\" height=\"300\" scalable=\"true\" maintainAspectRatio=\"true\">https://stagingams.pubmatic.com:8443/openwrap/media/mp4-sample-3.mp4</MediaFile></MediaFiles></Linear></Creative></Creatives></InLine></Ad></VAST>"
+var URLAdM = "http://pubmatic.com"
+
 // TestApplyAdvertiserBlocking verifies advertiser blocking
 // Currently it is expected to work only with TagBidders and not woth
 // normal bidders
@@ -1612,6 +1616,172 @@ func Test_updateSeatNonBidsFloors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			updateSeatNonBidsFloors(tt.args.seatNonBids, tt.args.rejectedBids)
 			assert.Equal(t, tt.expectedseatNonBids, tt.args.seatNonBids)
+		})
+	}
+}
+
+func TestRecordVastTag(t *testing.T) {
+	type args struct {
+		metricsEngine    metrics.MetricsEngine
+		adapterBids      map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid
+		getMetricsEngine func() *metrics.MetricsEngineMock
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "No Bids",
+			args: args{
+				adapterBids: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{},
+				getMetricsEngine: func() *metrics.MetricsEngineMock {
+					metricEngine := &metrics.MetricsEngineMock{}
+					return metricEngine
+				},
+			},
+		},
+		{
+			name: "Empty Bids in SeatBid",
+			args: args{
+				adapterBids: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{
+					"pubmatic": {
+						Bids: []*entities.PbsOrtbBid{},
+					},
+				},
+				getMetricsEngine: func() *metrics.MetricsEngineMock {
+					metricEngine := &metrics.MetricsEngineMock{}
+					return metricEngine
+				},
+			},
+		},
+		{
+			name: "Empty AdM",
+			args: args{
+				adapterBids: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{
+					"pubmatic": {
+						BidderCoreName: "pubmatic",
+						Bids: []*entities.PbsOrtbBid{
+							{
+								Bid: &openrtb2.Bid{
+									AdM: "",
+								},
+							},
+						},
+					},
+				},
+				getMetricsEngine: func() *metrics.MetricsEngineMock {
+					metricEngine := &metrics.MetricsEngineMock{}
+					metricEngine.Mock.On("RecordVastTag", "pubmatic", "Unknown").Return()
+					return metricEngine
+				},
+			},
+		},
+		{
+			name: "ADM has wrapped XML",
+			args: args{
+				adapterBids: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{
+					"pubmatic": {
+						BidderCoreName: "pubmatic",
+						Bids: []*entities.PbsOrtbBid{
+							{
+								Bid: &openrtb2.Bid{
+									AdM: vastXMLAdM,
+								},
+							},
+						},
+					},
+				},
+				getMetricsEngine: func() *metrics.MetricsEngineMock {
+					metricEngine := &metrics.MetricsEngineMock{}
+					metricEngine.Mock.On("RecordVastTag", "pubmatic", "Wrapper").Return()
+					return metricEngine
+				},
+			},
+		},
+		{
+			name: "ADM has Inline XML",
+			args: args{
+				adapterBids: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{
+					"pubmatic": {
+						BidderCoreName: "pubmatic",
+						Bids: []*entities.PbsOrtbBid{
+							{
+								Bid: &openrtb2.Bid{
+									AdM: inlineXMLAdM,
+								},
+							},
+						},
+					},
+				},
+				getMetricsEngine: func() *metrics.MetricsEngineMock {
+					metricEngine := &metrics.MetricsEngineMock{}
+					metricEngine.Mock.On("RecordVastTag", "pubmatic", "InLine").Return()
+					return metricEngine
+				},
+			},
+		},
+		{
+			name: "ADM has URL",
+			args: args{
+				adapterBids: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{
+					"pubmatic": {
+						BidderCoreName: "pubmatic",
+						Bids: []*entities.PbsOrtbBid{
+							{
+								Bid: &openrtb2.Bid{
+									AdM: URLAdM,
+								},
+							},
+						},
+					},
+				},
+				getMetricsEngine: func() *metrics.MetricsEngineMock {
+					metricEngine := &metrics.MetricsEngineMock{}
+					metricEngine.Mock.On("RecordVastTag", "pubmatic", "URL").Return()
+					return metricEngine
+				},
+			},
+		},
+		{
+			name: "ADM has Wrapper,InLine and URL ADM",
+			args: args{
+				adapterBids: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{
+					"pubmatic": {
+						BidderCoreName: "pubmatic",
+						Bids: []*entities.PbsOrtbBid{
+							{
+								Bid: &openrtb2.Bid{
+									AdM: vastXMLAdM,
+								},
+							},
+							{
+								Bid: &openrtb2.Bid{
+									AdM: inlineXMLAdM,
+								},
+							},
+							{
+								Bid: &openrtb2.Bid{
+									AdM: URLAdM,
+								},
+							},
+						},
+					},
+				},
+				getMetricsEngine: func() *metrics.MetricsEngineMock {
+					metricEngine := &metrics.MetricsEngineMock{}
+					metricEngine.Mock.On("RecordVastTag", "pubmatic", "Wrapper").Return()
+					metricEngine.Mock.On("RecordVastTag", "pubmatic", "InLine").Return()
+					metricEngine.Mock.On("RecordVastTag", "pubmatic", "URL").Return()
+					return metricEngine
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockMetricEngine := tt.args.getMetricsEngine()
+			recordVastTag(mockMetricEngine, tt.args.adapterBids)
+			mockMetricEngine.AssertExpectations(t)
 		})
 	}
 }

--- a/exchange/exchange_ow_test.go
+++ b/exchange/exchange_ow_test.go
@@ -23,10 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var vastXMLAdM = "<VAST version='3.0'><Ad id='1'><Wrapper><AdSystem>PubMatic</AdSystem><VASTAdTagURI><![CDATA[https://owsdk-stagingams.pubmatic.com:8443/openwrap/video/Shashank/dspResponse/vastInline.php?m=1&x=3&y=3&p=11&va=3&sc=1]]></VASTAdTagURI><Error><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&er=[ERRORCODE]]]></Error><Impression><![CDATA[https://aktrack.pubmatic.com/AdServer/AdDisplayTrackerServlet?operId=1&pubId=64195&siteId=47105&adId=1405154&adType=13&adServerId=243&kefact=1.000000&kaxefact=1.000000&kadNetFrequecy=0&kadwidth=0&kadheight=0&kadsizeid=97&kltstamp=1536933242&indirectAdId=0&adServerOptimizerId=2&ranreq=0.05969169352174375&kpbmtpfact=11.000000&dcId=1&tldId=0&passback=0&svr=ktk57&ekefact=er2bW2sDAwCra06ACbsIQySn5nqBtYsTl8fy5lupAexh37D_&ekaxefact=er2bW4EDAwB_LQpJJ23Fq0DcNC-NSAFXdpSQC8XBk_S33_Fa&ekpbmtpfact=er2bW5MDAwDJHdBnLBt5IrRuh7x0oqp_tjIALv_VvSQDAl6R&crID=m:1_x:3_y:3_p:11_va:3&lpu=ae.com&ucrid=678722001014421372&campaignId=16774&creativeId=0&pctr=0.000000&wDSPByrId=511&wDspId=27&wbId=0&wrId=0&wAdvID=3170&isRTB=1&rtbId=EBCA079F-8D7C-45B8-B733-92951F670AA1&imprId=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&oid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&pageURL=http%253A%252F%252Fowsdk-stagingams.pubmatic.com%253A8443%252Fvast-validator%252F%2523&sec=1&pmc=1]]></Impression><Creatives><Creative><Linear><TrackingEvents><Tracking event='creativeView'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=1]]></Tracking><Tracking event='start'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=2]]></Tracking><Tracking event='midpoint'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=3]]></Tracking><Tracking event='firstQuartile'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=4]]></Tracking><Tracking event='thirdQuartile'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=5]]></Tracking><Tracking event='complete'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=6]]></Tracking></TrackingEvents><VideoClicks><ClickTracking><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=99]]></ClickTracking></VideoClicks></Linear></Creative><Creative><NonLinearAds><TrackingEvents><Tracking event='creativeView'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=1]]></Tracking><Tracking event='start'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=2]]></Tracking><Tracking event='midpoint'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=3]]></Tracking><Tracking event='firstQuartile'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=4]]></Tracking><Tracking event='thirdQuartile'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=5]]></Tracking><Tracking event='complete'><![CDATA[https://aktrack.pubmatic.com/track?operId=7&p=64195&s=47105&a=1405154&wa=243&ts=1536933242&wc=16774&crId=m:1_x:3_y:3_p:11_va:3&ucrid=678722001014421372&impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&advertiser_id=3170&ecpm=1.000000&e=6]]></Tracking></TrackingEvents></NonLinearAds></Creative></Creatives></Wrapper></Ad></VAST>"
-var inlineXMLAdM = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?><VAST version=\"3.0\"><Ad id=\"1329167\"><InLine><AdSystem>Acudeo Compatible</AdSystem><AdTitle>VAST 2.0 Instream Test 1</AdTitle><Description>VAST 2.0 Instream Test 1</Description><Error>https://aktrack.pubmatic.com/track?operId=7&amp;p=64195&amp;s=47105&amp;a=1405154&amp;wa=243&amp;ts=1536933242&amp;wc=16774&amp;crId=m:1_x:3_y:3_p:11_va:3&amp;ucrid=678722001014421372&amp;impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;advertiser_id=3170&amp;ecpm=1.000000&amp;er=[ERRORCODE]</Error><Error>https://track.dsptracker.com?p=1234&amp;er=[ERRORCODE]</Error><Impression>https://aktrack.pubmatic.com/AdServer/AdDisplayTrackerServlet?operId=1&amp;pubId=64195&amp;siteId=47105&amp;adId=1405154&amp;adType=13&amp;adServerId=243&amp;kefact=1.000000&amp;kaxefact=1.000000&amp;kadNetFrequecy=0&amp;kadwidth=0&amp;kadheight=0&amp;kadsizeid=97&amp;kltstamp=1536933242&amp;indirectAdId=0&amp;adServerOptimizerId=2&amp;ranreq=0.05969169352174375&amp;kpbmtpfact=11.000000&amp;dcId=1&amp;tldId=0&amp;passback=0&amp;svr=ktk57&amp;ekefact=er2bW2sDAwCra06ACbsIQySn5nqBtYsTl8fy5lupAexh37D_&amp;ekaxefact=er2bW4EDAwB_LQpJJ23Fq0DcNC-NSAFXdpSQC8XBk_S33_Fa&amp;ekpbmtpfact=er2bW5MDAwDJHdBnLBt5IrRuh7x0oqp_tjIALv_VvSQDAl6R&amp;crID=m:1_x:3_y:3_p:11_va:3&amp;lpu=ae.com&amp;ucrid=678722001014421372&amp;campaignId=16774&amp;creativeId=0&amp;pctr=0.000000&amp;wDSPByrId=511&amp;wDspId=27&amp;wbId=0&amp;wrId=0&amp;wAdvID=3170&amp;isRTB=1&amp;rtbId=EBCA079F-8D7C-45B8-B733-92951F670AA1&amp;imprId=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;oid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;pageURL=http%253A%252F%252Fowsdk-stagingams.pubmatic.com%253A8443%252Fvast-validator%252F%2523&amp;sec=1&amp;pmc=1</Impression><Impression>https://DspImpressionTracker.com/</Impression><Creatives><Creative AdID=\"1329167\"><Linear skipoffset=\"20%\"><TrackingEvents><Tracking event=\"close\">https://mytracking.com/linear/close</Tracking><Tracking event=\"skip\">https://mytracking.com/linear/skip</Tracking><Tracking event=\"creativeView\">https://aktrack.pubmatic.com/track?operId=7&amp;p=64195&amp;s=47105&amp;a=1405154&amp;wa=243&amp;ts=1536933242&amp;wc=16774&amp;crId=m:1_x:3_y:3_p:11_va:3&amp;ucrid=678722001014421372&amp;impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;advertiser_id=3170&amp;ecpm=1.000000&amp;e=1</Tracking><Tracking event=\"start\">https://aktrack.pubmatic.com/track?operId=7&amp;p=64195&amp;s=47105&amp;a=1405154&amp;wa=243&amp;ts=1536933242&amp;wc=16774&amp;crId=m:1_x:3_y:3_p:11_va:3&amp;ucrid=678722001014421372&amp;impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;advertiser_id=3170&amp;ecpm=1.000000&amp;e=2</Tracking><Tracking event=\"midpoint\">https://aktrack.pubmatic.com/track?operId=7&amp;p=64195&amp;s=47105&amp;a=1405154&amp;wa=243&amp;ts=1536933242&amp;wc=16774&amp;crId=m:1_x:3_y:3_p:11_va:3&amp;ucrid=678722001014421372&amp;impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;advertiser_id=3170&amp;ecpm=1.000000&amp;e=3</Tracking><Tracking event=\"firstQuartile\">https://aktrack.pubmatic.com/track?operId=7&amp;p=64195&amp;s=47105&amp;a=1405154&amp;wa=243&amp;ts=1536933242&amp;wc=16774&amp;crId=m:1_x:3_y:3_p:11_va:3&amp;ucrid=678722001014421372&amp;impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;advertiser_id=3170&amp;ecpm=1.000000&amp;e=4</Tracking><Tracking event=\"thirdQuartile\">https://aktrack.pubmatic.com/track?operId=7&amp;p=64195&amp;s=47105&amp;a=1405154&amp;wa=243&amp;ts=1536933242&amp;wc=16774&amp;crId=m:1_x:3_y:3_p:11_va:3&amp;ucrid=678722001014421372&amp;impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;advertiser_id=3170&amp;ecpm=1.000000&amp;e=5</Tracking><Tracking event=\"complete\">https://aktrack.pubmatic.com/track?operId=7&amp;p=64195&amp;s=47105&amp;a=1405154&amp;wa=243&amp;ts=1536933242&amp;wc=16774&amp;crId=m:1_x:3_y:3_p:11_va:3&amp;ucrid=678722001014421372&amp;impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;advertiser_id=3170&amp;ecpm=1.000000&amp;e=6</Tracking></TrackingEvents><Duration>00:00:04</Duration><VideoClicks><ClickThrough>https://www.automationtester.in</ClickThrough><ClickTracking>https://aktrack.pubmatic.com/track?operId=7&amp;p=64195&amp;s=47105&amp;a=1405154&amp;wa=243&amp;ts=1536933242&amp;wc=16774&amp;crId=m:1_x:3_y:3_p:11_va:3&amp;ucrid=678722001014421372&amp;impid=24D9FEDA-C97D-4DF7-B747-BD3CFF5AC7B5&amp;advertiser_id=3170&amp;ecpm=1.000000&amp;e=99</ClickTracking></VideoClicks><MediaFiles><MediaFile delivery=\"progressive\" type=\"video/mp4\" bitrate=\"500\" width=\"400\" height=\"300\" scalable=\"true\" maintainAspectRatio=\"true\">https://stagingams.pubmatic.com:8443/openwrap/media/pubmatic.mp4</MediaFile><MediaFile delivery=\"progressive\" type=\"video/mp4\" bitrate=\"500\" width=\"400\" height=\"300\" scalable=\"true\" maintainAspectRatio=\"true\">https://stagingams.pubmatic.com:8443/openwrap/media/pubmatic.mp4</MediaFile><MediaFile delivery=\"progressive\" type=\"video/mp4\" bitrate=\"500\" width=\"400\" height=\"300\" scalable=\"true\" maintainAspectRatio=\"true\">https://stagingams.pubmatic.com:8443/openwrap/media/mp4-sample-3.mp4</MediaFile></MediaFiles></Linear></Creative></Creatives></InLine></Ad></VAST>"
-var URLAdM = "http://pubmatic.com"
-
 // TestApplyAdvertiserBlocking verifies advertiser blocking
 // Currently it is expected to work only with TagBidders and not woth
 // normal bidders
@@ -1620,7 +1616,10 @@ func Test_updateSeatNonBidsFloors(t *testing.T) {
 	}
 }
 
-func TestRecordVastTag(t *testing.T) {
+func TestRecordVASTTagType(t *testing.T) {
+	var vastXMLAdM = "<VAST version='3.0'><Ad><Wrapper><VASTAdTagURI><![CDATA[https://owsdk-stagingams.pubmatic.com:8443/openwrap/video/Shashank/dspResponse/vastInline.php?m=1&x=3&y=3&p=11&va=3&sc=1]]></VASTAdTagURI></Wrapper></Ad></VAST>"
+	var inlineXMLAdM = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?><VAST version=\"3.0\"><Ad id=\"1329167\"><InLine><AdSystem>Acudeo Compatible</AdSystem><AdTitle>VAST 2.0 Instream Test 1</AdTitle><Description>VAST 2.0 Instream Test 1</Description></InLine></Ad></VAST>"
+	var URLAdM = "http://pubmatic.com"
 	type args struct {
 		metricsEngine    metrics.MetricsEngine
 		adapterBids      *adapters.BidderResponse
@@ -1631,7 +1630,7 @@ func TestRecordVastTag(t *testing.T) {
 		args args
 	}{
 		{
-			name: "No Bids",
+			name: "no_bids",
 			args: args{
 				adapterBids: &adapters.BidderResponse{},
 				getMetricsEngine: func() *metrics.MetricsEngineMock {
@@ -1641,7 +1640,7 @@ func TestRecordVastTag(t *testing.T) {
 			},
 		},
 		{
-			name: "Empty Bids in SeatBid",
+			name: "empty_bids_in_seatbids",
 			args: args{
 				adapterBids: &adapters.BidderResponse{
 					Bids: []*adapters.TypedBid{},
@@ -1653,7 +1652,7 @@ func TestRecordVastTag(t *testing.T) {
 			},
 		},
 		{
-			name: "Empty AdM",
+			name: "empty_adm",
 			args: args{
 				adapterBids: &adapters.BidderResponse{
 					Bids: []*adapters.TypedBid{
@@ -1674,7 +1673,7 @@ func TestRecordVastTag(t *testing.T) {
 			},
 		},
 		{
-			name: "ADM has wrapped XML",
+			name: "adm_has_wrapped_xml",
 			args: args{
 				adapterBids: &adapters.BidderResponse{
 					Bids: []*adapters.TypedBid{
@@ -1695,7 +1694,7 @@ func TestRecordVastTag(t *testing.T) {
 			},
 		},
 		{
-			name: "ADM has Inline XML",
+			name: "adm_has_inline_xml",
 			args: args{
 				adapterBids: &adapters.BidderResponse{
 					Bids: []*adapters.TypedBid{
@@ -1716,7 +1715,7 @@ func TestRecordVastTag(t *testing.T) {
 			},
 		},
 		{
-			name: "ADM has URL",
+			name: "adm_has_url",
 			args: args{
 				adapterBids: &adapters.BidderResponse{
 					Bids: []*adapters.TypedBid{
@@ -1737,7 +1736,7 @@ func TestRecordVastTag(t *testing.T) {
 			},
 		},
 		{
-			name: "ADM has Wrapper,InLine and URL ADM",
+			name: "adm_has_wrapper_inline_url_adm",
 			args: args{
 				adapterBids: &adapters.BidderResponse{
 					Bids: []*adapters.TypedBid{
@@ -1777,8 +1776,55 @@ func TestRecordVastTag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockMetricEngine := tt.args.getMetricsEngine()
-			recordVastTag(mockMetricEngine, tt.args.adapterBids, "pubmatic")
+			recordVASTTagType(mockMetricEngine, tt.args.adapterBids, "pubmatic")
 			mockMetricEngine.AssertExpectations(t)
+		})
+	}
+}
+
+func TestIsUrl(t *testing.T) {
+	type args struct {
+		adm string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "empty_url",
+			args: args{
+				adm: "",
+			},
+			want: false,
+		},
+		{
+			name: "valid_url",
+			args: args{
+				adm: "http://www.test.com",
+			},
+			want: true,
+		},
+		{
+			name: "invalid_url_without_protocol",
+			args: args{
+				adm: "//www.test.com/vast.xml",
+			},
+			want: false,
+		},
+		{
+			name: "invalid_url_without_host",
+			args: args{
+				adm: "http://",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsUrl(tt.args.adm); got != tt.want {
+				t.Errorf("IsUrl() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/exchange/exchange_ow_test.go
+++ b/exchange/exchange_ow_test.go
@@ -1667,7 +1667,7 @@ func TestRecordVASTTagType(t *testing.T) {
 				},
 				getMetricsEngine: func() *metrics.MetricsEngineMock {
 					metricEngine := &metrics.MetricsEngineMock{}
-					metricEngine.Mock.On("RecordVastTag", "pubmatic", "Unknown").Return()
+					metricEngine.Mock.On("RecordVASTTagType", "pubmatic", "Unknown").Return()
 					return metricEngine
 				},
 			},
@@ -1688,7 +1688,7 @@ func TestRecordVASTTagType(t *testing.T) {
 				},
 				getMetricsEngine: func() *metrics.MetricsEngineMock {
 					metricEngine := &metrics.MetricsEngineMock{}
-					metricEngine.Mock.On("RecordVastTag", "pubmatic", "Wrapper").Return()
+					metricEngine.Mock.On("RecordVASTTagType", "pubmatic", "Wrapper").Return()
 					return metricEngine
 				},
 			},
@@ -1709,7 +1709,7 @@ func TestRecordVASTTagType(t *testing.T) {
 				},
 				getMetricsEngine: func() *metrics.MetricsEngineMock {
 					metricEngine := &metrics.MetricsEngineMock{}
-					metricEngine.Mock.On("RecordVastTag", "pubmatic", "InLine").Return()
+					metricEngine.Mock.On("RecordVASTTagType", "pubmatic", "InLine").Return()
 					return metricEngine
 				},
 			},
@@ -1730,7 +1730,7 @@ func TestRecordVASTTagType(t *testing.T) {
 				},
 				getMetricsEngine: func() *metrics.MetricsEngineMock {
 					metricEngine := &metrics.MetricsEngineMock{}
-					metricEngine.Mock.On("RecordVastTag", "pubmatic", "URL").Return()
+					metricEngine.Mock.On("RecordVASTTagType", "pubmatic", "URL").Return()
 					return metricEngine
 				},
 			},
@@ -1765,9 +1765,9 @@ func TestRecordVASTTagType(t *testing.T) {
 				},
 				getMetricsEngine: func() *metrics.MetricsEngineMock {
 					metricEngine := &metrics.MetricsEngineMock{}
-					metricEngine.Mock.On("RecordVastTag", "pubmatic", "Wrapper").Return()
-					metricEngine.Mock.On("RecordVastTag", "pubmatic", "InLine").Return()
-					metricEngine.Mock.On("RecordVastTag", "pubmatic", "URL").Return()
+					metricEngine.Mock.On("RecordVASTTagType", "pubmatic", "Wrapper").Return()
+					metricEngine.Mock.On("RecordVASTTagType", "pubmatic", "InLine").Return()
+					metricEngine.Mock.On("RecordVASTTagType", "pubmatic", "URL").Return()
 					return metricEngine
 				},
 			},

--- a/exchange/exchange_ow_test.go
+++ b/exchange/exchange_ow_test.go
@@ -1623,7 +1623,7 @@ func Test_updateSeatNonBidsFloors(t *testing.T) {
 func TestRecordVastTag(t *testing.T) {
 	type args struct {
 		metricsEngine    metrics.MetricsEngine
-		adapterBids      map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid
+		adapterBids      *adapters.BidderResponse
 		getMetricsEngine func() *metrics.MetricsEngineMock
 	}
 	tests := []struct {
@@ -1633,7 +1633,7 @@ func TestRecordVastTag(t *testing.T) {
 		{
 			name: "No Bids",
 			args: args{
-				adapterBids: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{},
+				adapterBids: &adapters.BidderResponse{},
 				getMetricsEngine: func() *metrics.MetricsEngineMock {
 					metricEngine := &metrics.MetricsEngineMock{}
 					return metricEngine
@@ -1643,10 +1643,8 @@ func TestRecordVastTag(t *testing.T) {
 		{
 			name: "Empty Bids in SeatBid",
 			args: args{
-				adapterBids: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{
-					"pubmatic": {
-						Bids: []*entities.PbsOrtbBid{},
-					},
+				adapterBids: &adapters.BidderResponse{
+					Bids: []*adapters.TypedBid{},
 				},
 				getMetricsEngine: func() *metrics.MetricsEngineMock {
 					metricEngine := &metrics.MetricsEngineMock{}
@@ -1657,15 +1655,14 @@ func TestRecordVastTag(t *testing.T) {
 		{
 			name: "Empty AdM",
 			args: args{
-				adapterBids: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{
-					"pubmatic": {
-						BidderCoreName: "pubmatic",
-						Bids: []*entities.PbsOrtbBid{
-							{
-								Bid: &openrtb2.Bid{
-									AdM: "",
-								},
+				adapterBids: &adapters.BidderResponse{
+					Bids: []*adapters.TypedBid{
+						{
+							Bid: &openrtb2.Bid{
+								AdM: "",
 							},
+							Seat:    "pubmatic",
+							BidType: openrtb_ext.BidTypeVideo,
 						},
 					},
 				},
@@ -1679,15 +1676,14 @@ func TestRecordVastTag(t *testing.T) {
 		{
 			name: "ADM has wrapped XML",
 			args: args{
-				adapterBids: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{
-					"pubmatic": {
-						BidderCoreName: "pubmatic",
-						Bids: []*entities.PbsOrtbBid{
-							{
-								Bid: &openrtb2.Bid{
-									AdM: vastXMLAdM,
-								},
+				adapterBids: &adapters.BidderResponse{
+					Bids: []*adapters.TypedBid{
+						{
+							Bid: &openrtb2.Bid{
+								AdM: vastXMLAdM,
 							},
+							Seat:    "pubmatic",
+							BidType: openrtb_ext.BidTypeVideo,
 						},
 					},
 				},
@@ -1701,15 +1697,14 @@ func TestRecordVastTag(t *testing.T) {
 		{
 			name: "ADM has Inline XML",
 			args: args{
-				adapterBids: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{
-					"pubmatic": {
-						BidderCoreName: "pubmatic",
-						Bids: []*entities.PbsOrtbBid{
-							{
-								Bid: &openrtb2.Bid{
-									AdM: inlineXMLAdM,
-								},
+				adapterBids: &adapters.BidderResponse{
+					Bids: []*adapters.TypedBid{
+						{
+							Bid: &openrtb2.Bid{
+								AdM: inlineXMLAdM,
 							},
+							Seat:    "pubmatic",
+							BidType: openrtb_ext.BidTypeVideo,
 						},
 					},
 				},
@@ -1723,15 +1718,14 @@ func TestRecordVastTag(t *testing.T) {
 		{
 			name: "ADM has URL",
 			args: args{
-				adapterBids: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{
-					"pubmatic": {
-						BidderCoreName: "pubmatic",
-						Bids: []*entities.PbsOrtbBid{
-							{
-								Bid: &openrtb2.Bid{
-									AdM: URLAdM,
-								},
+				adapterBids: &adapters.BidderResponse{
+					Bids: []*adapters.TypedBid{
+						{
+							Bid: &openrtb2.Bid{
+								AdM: URLAdM,
 							},
+							Seat:    "pubmatic",
+							BidType: openrtb_ext.BidTypeVideo,
 						},
 					},
 				},
@@ -1745,25 +1739,28 @@ func TestRecordVastTag(t *testing.T) {
 		{
 			name: "ADM has Wrapper,InLine and URL ADM",
 			args: args{
-				adapterBids: map[openrtb_ext.BidderName]*entities.PbsOrtbSeatBid{
-					"pubmatic": {
-						BidderCoreName: "pubmatic",
-						Bids: []*entities.PbsOrtbBid{
-							{
-								Bid: &openrtb2.Bid{
-									AdM: vastXMLAdM,
-								},
+				adapterBids: &adapters.BidderResponse{
+					Bids: []*adapters.TypedBid{
+						{
+							Bid: &openrtb2.Bid{
+								AdM: vastXMLAdM,
 							},
-							{
-								Bid: &openrtb2.Bid{
-									AdM: inlineXMLAdM,
-								},
+							Seat:    "pubmatic",
+							BidType: openrtb_ext.BidTypeVideo,
+						},
+						{
+							Bid: &openrtb2.Bid{
+								AdM: inlineXMLAdM,
 							},
-							{
-								Bid: &openrtb2.Bid{
-									AdM: URLAdM,
-								},
+							Seat:    "pubmatic",
+							BidType: openrtb_ext.BidTypeVideo,
+						},
+						{
+							Bid: &openrtb2.Bid{
+								AdM: URLAdM,
 							},
+							Seat:    "pubmatic",
+							BidType: openrtb_ext.BidTypeVideo,
 						},
 					},
 				},

--- a/metrics/config/metrics.go
+++ b/metrics/config/metrics.go
@@ -150,20 +150,6 @@ func (me *MultiMetricsEngine) RecordAdapterRequest(labels metrics.AdapterLabels)
 	}
 }
 
-// RecordRejectedBidsForBidder across all engines
-func (me *MultiMetricsEngine) RecordRejectedBidsForBidder(bidder openrtb_ext.BidderName) {
-	for _, thisME := range *me {
-		thisME.RecordRejectedBidsForBidder(bidder)
-	}
-}
-
-// RecordDynamicFetchFailure across all engines
-func (me *MultiMetricsEngine) RecordDynamicFetchFailure(pubId, code string) {
-	for _, thisME := range *me {
-		thisME.RecordDynamicFetchFailure(pubId, code)
-	}
-}
-
 // Keeps track of created and reused connections to adapter bidders and the time from the
 // connection request, to the connection creation, or reuse from the pool across all engines
 func (me *MultiMetricsEngine) RecordAdapterConnections(bidderName openrtb_ext.BidderName, connWasReused bool, connWaitTime time.Duration) {
@@ -317,10 +303,6 @@ func (me *MultiMetricsEngine) RecordPodImpGenTime(labels metrics.PodLabels, star
 	}
 }
 
-// RecordRejectedBidsForBidder as a noop
-func (me *NilMetricsEngine) RecordRejectedBidsForBidder(bidder openrtb_ext.BidderName) {
-}
-
 // RecordPodCombGenTime as a noop
 func (me *MultiMetricsEngine) RecordPodCombGenTime(labels metrics.PodLabels, elapsedTime time.Duration) {
 	for _, thisME := range *me {
@@ -470,31 +452,6 @@ func (me *MultiMetricsEngine) RecordModuleExecutionError(labels metrics.ModuleLa
 func (me *MultiMetricsEngine) RecordModuleTimeout(labels metrics.ModuleLabels) {
 	for _, thisME := range *me {
 		thisME.RecordModuleTimeout(labels)
-	}
-}
-func (me *MultiMetricsEngine) RecordRejectedBids(pubid, bidder, code string) {
-	for _, thisME := range *me {
-		thisME.RecordRejectedBids(pubid, bidder, code)
-	}
-}
-
-func (me *MultiMetricsEngine) RecordBids(pubid, profileid, biddder, deal string) {
-	for _, thisME := range *me {
-		thisME.RecordBids(pubid, profileid, biddder, deal)
-	}
-}
-func (me *MultiMetricsEngine) RecordHttpCounter() {
-}
-
-func (me *MultiMetricsEngine) RecordVastVersion(biddder, vastVersion string) {
-	for _, thisME := range *me {
-		thisME.RecordVastVersion(biddder, vastVersion)
-	}
-}
-
-func (me *MultiMetricsEngine) RecordVastTag(biddder, vastTag string) {
-	for _, thisME := range *me {
-		thisME.RecordVastTag(biddder, vastTag)
 	}
 }
 
@@ -704,27 +661,4 @@ func (me *NilMetricsEngine) RecordModuleExecutionError(labels metrics.ModuleLabe
 }
 
 func (me *NilMetricsEngine) RecordModuleTimeout(labels metrics.ModuleLabels) {
-}
-
-// RecordDynamicFetchFailure as a noop
-func (me *NilMetricsEngine) RecordDynamicFetchFailure(pubId, code string) {
-}
-
-// RecordRejectedBids as a noop
-func (me *NilMetricsEngine) RecordRejectedBids(pubid, bidder, code string) {
-}
-
-// RecordBids as a noop
-func (me *NilMetricsEngine) RecordBids(pubid, profileid, biddder, deal string) {
-}
-
-// RecordVastVersion as a noop
-func (me *NilMetricsEngine) RecordVastVersion(biddder, vastVersion string) {
-}
-
-func (m *NilMetricsEngine) RecordHttpCounter() {
-}
-
-// RecordVastTag as a noop
-func (me *NilMetricsEngine) RecordVastTag(biddder, vastTag string) {
 }

--- a/metrics/config/metrics.go
+++ b/metrics/config/metrics.go
@@ -492,6 +492,12 @@ func (me *MultiMetricsEngine) RecordVastVersion(biddder, vastVersion string) {
 	}
 }
 
+func (me *MultiMetricsEngine) RecordVastTag(biddder, vastTag string) {
+	for _, thisME := range *me {
+		thisME.RecordVastTag(biddder, vastTag)
+	}
+}
+
 // NilMetricsEngine implements the MetricsEngine interface where no metrics are actually captured. This is
 // used if no metric backend is configured and also for tests.
 type NilMetricsEngine struct{}
@@ -717,4 +723,8 @@ func (me *NilMetricsEngine) RecordVastVersion(biddder, vastVersion string) {
 }
 
 func (m *NilMetricsEngine) RecordHttpCounter() {
+}
+
+// RecordVastTag as a noop
+func (me *NilMetricsEngine) RecordVastTag(biddder, vastTag string) {
 }

--- a/metrics/config/metrics_ow.go
+++ b/metrics/config/metrics_ow.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/prebid/prebid-server/openrtb_ext"
 	"github.com/prometheus/client_golang/prometheus"
 	gometrics "github.com/rcrowley/go-metrics"
 )
@@ -19,4 +20,71 @@ func NewMetricsRegistry() MetricsRegistry {
 		PrometheusRegistry: prometheus.NewRegistry(),
 		InfluxRegistry:     gometrics.NewPrefixedRegistry("prebidserver."),
 	}
+}
+
+func (me *MultiMetricsEngine) RecordVASTTagType(biddder, vastTag string) {
+	for _, thisME := range *me {
+		thisME.RecordVASTTagType(biddder, vastTag)
+	}
+}
+
+func (me *MultiMetricsEngine) RecordRejectedBids(pubid, bidder, code string) {
+	for _, thisME := range *me {
+		thisME.RecordRejectedBids(pubid, bidder, code)
+	}
+}
+
+func (me *MultiMetricsEngine) RecordBids(pubid, profileid, biddder, deal string) {
+	for _, thisME := range *me {
+		thisME.RecordBids(pubid, profileid, biddder, deal)
+	}
+}
+func (me *MultiMetricsEngine) RecordHttpCounter() {
+}
+
+func (me *MultiMetricsEngine) RecordVastVersion(biddder, vastVersion string) {
+	for _, thisME := range *me {
+		thisME.RecordVastVersion(biddder, vastVersion)
+	}
+}
+
+// RecordRejectedBidsForBidder across all engines
+func (me *MultiMetricsEngine) RecordRejectedBidsForBidder(bidder openrtb_ext.BidderName) {
+	for _, thisME := range *me {
+		thisME.RecordRejectedBidsForBidder(bidder)
+	}
+}
+
+// RecordDynamicFetchFailure across all engines
+func (me *MultiMetricsEngine) RecordDynamicFetchFailure(pubId, code string) {
+	for _, thisME := range *me {
+		thisME.RecordDynamicFetchFailure(pubId, code)
+	}
+}
+
+// RecordVASTTagType as a noop
+func (me *NilMetricsEngine) RecordVASTTagType(biddder, vastTag string) {
+}
+
+// RecordDynamicFetchFailure as a noop
+func (me *NilMetricsEngine) RecordDynamicFetchFailure(pubId, code string) {
+}
+
+// RecordRejectedBids as a noop
+func (me *NilMetricsEngine) RecordRejectedBids(pubid, bidder, code string) {
+}
+
+// RecordBids as a noop
+func (me *NilMetricsEngine) RecordBids(pubid, profileid, biddder, deal string) {
+}
+
+// RecordVastVersion as a noop
+func (me *NilMetricsEngine) RecordVastVersion(biddder, vastVersion string) {
+}
+
+func (m *NilMetricsEngine) RecordHttpCounter() {
+}
+
+// RecordRejectedBidsForBidder as a noop
+func (me *NilMetricsEngine) RecordRejectedBidsForBidder(bidder openrtb_ext.BidderName) {
 }

--- a/metrics/go_metrics_ow.go
+++ b/metrics/go_metrics_ow.go
@@ -41,6 +41,6 @@ func (me *Metrics) RecordVastVersion(biddder, vastVersion string) {
 func (me *Metrics) RecordHttpCounter() {
 }
 
-// RecordVastTag as a noop
-func (me *Metrics) RecordVastTag(biddder, vastTag string) {
+// RecordVASTTagType as a noop
+func (me *Metrics) RecordVASTTagType(biddder, vastTag string) {
 }

--- a/metrics/go_metrics_ow.go
+++ b/metrics/go_metrics_ow.go
@@ -40,3 +40,7 @@ func (me *Metrics) RecordVastVersion(biddder, vastVersion string) {
 
 func (me *Metrics) RecordHttpCounter() {
 }
+
+// RecordVastTag as a noop
+func (me *Metrics) RecordVastTag(biddder, vastTag string) {
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -528,5 +528,8 @@ type MetricsEngine interface {
 	//RecordVastVersion record the count of vast version labelled by bidder and vast version
 	RecordVastVersion(coreBidder, vastVersion string)
 
+	//RecordVastTag record the count of vast tag type labeled by bidder and vast tag
+	RecordVastTag(bidder, vastTag string)
+
 	RecordHttpCounter()
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -429,6 +429,7 @@ func SyncerSetUidStatuses() []SyncerSetUidStatus {
 // two groups should be consistent within themselves, but comparing numbers between groups
 // is generally not useful.
 type MetricsEngine interface {
+	OWMetricsEngine
 	RecordConnectionAccept(success bool)
 	RecordTMaxTimeout()
 	RecordConnectionClose(success bool)
@@ -521,15 +522,4 @@ type MetricsEngine interface {
 
 	//RecordRejectedBids records the rejected bids labeled by pubid, bidder and reason code
 	RecordRejectedBids(pubid, bidder, code string)
-
-	//RecordBids records the bidder deal bids labeled by pubid, profile, bidder and deal
-	RecordBids(pubid, profileid, bidder, deal string)
-
-	//RecordVastVersion record the count of vast version labelled by bidder and vast version
-	RecordVastVersion(coreBidder, vastVersion string)
-
-	//RecordVastTag record the count of vast tag type labeled by bidder and vast tag
-	RecordVastTag(bidder, vastTag string)
-
-	RecordHttpCounter()
 }

--- a/metrics/metrics_mock_ow.go
+++ b/metrics/metrics_mock_ow.go
@@ -40,3 +40,8 @@ func (me *MetricsEngineMock) RecordBids(pubid, profileid, biddder, deal string) 
 func (me *MetricsEngineMock) RecordVastVersion(coreBidder, vastVersion string) {
 	me.Called(coreBidder, vastVersion)
 }
+
+// RecordVastTag mock
+func (me *MetricsEngineMock) RecordVastTag(bidder, vastTag string) {
+	me.Called(bidder, vastTag)
+}

--- a/metrics/metrics_mock_ow.go
+++ b/metrics/metrics_mock_ow.go
@@ -41,7 +41,7 @@ func (me *MetricsEngineMock) RecordVastVersion(coreBidder, vastVersion string) {
 	me.Called(coreBidder, vastVersion)
 }
 
-// RecordVastTag mock
-func (me *MetricsEngineMock) RecordVastTag(bidder, vastTag string) {
-	me.Called(bidder, vastTag)
+// RecordVASTTagType mock
+func (me *MetricsEngineMock) RecordVASTTagType(bidder, vastTagType string) {
+	me.Called(bidder, vastTagType)
 }

--- a/metrics/metrics_ow.go
+++ b/metrics/metrics_ow.go
@@ -1,0 +1,11 @@
+package metrics
+
+type OWMetricsEngine interface {
+	RecordHttpCounter()
+	//RecordBids records the bidder deal bids labeled by pubid, profile, bidder and deal
+	RecordBids(pubid, profileid, bidder, deal string)
+	//RecordVastVersion record the count of vast version labelled by bidder and vast version
+	RecordVastVersion(coreBidder, vastVersion string)
+	//RecordVASTTagType record the count of vast tag type labeled by bidder and vast tag
+	RecordVASTTagType(bidder, vastTagType string)
+}

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -88,6 +88,7 @@ type Metrics struct {
 	rejectedBids *prometheus.CounterVec
 	bids         *prometheus.CounterVec
 	vastVersion  *prometheus.CounterVec
+	vastTag      *prometheus.CounterVec
 	//rejectedBids         *prometheus.CounterVec
 	accountRejectedBid   *prometheus.CounterVec
 	accountFloorsRequest *prometheus.CounterVec
@@ -573,6 +574,11 @@ func NewMetrics(cfg config.PrometheusMetrics, reg *prometheus.Registry, disabled
 		"vast_version",
 		"Count of vast version by bidder and vast version",
 		[]string{adapterLabel, versionLabel})
+
+	metrics.vastTag = newCounter(cfg, reg,
+		"vast_tag",
+		"Count of vast tag by bidder and vast tag",
+		[]string{bidderLabel, vastTagLabel})
 
 	metrics.dynamicFetchFailure = newCounter(cfg, reg,
 		"floors_account_fetch_err",

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -117,7 +117,6 @@ type Metrics struct {
 	// Ad Pod Metrics
 
 	metricsDisabled config.DisabledMetrics
-	httpCounter     prometheus.Counter
 }
 
 const (
@@ -590,9 +589,6 @@ func NewMetrics(cfg config.PrometheusMetrics, reg *prometheus.Registry, disabled
 	metrics.Registerer = prometheus.WrapRegistererWithPrefix(metricsPrefix, reg)
 	metrics.Registerer.MustRegister(promCollector.NewGoCollector())
 	preloadLabelValues(&metrics, syncerKeys, moduleStageNames)
-
-	metrics.httpCounter = newHttpCounter(cfg, reg)
-
 	return &metrics
 }
 
@@ -899,9 +895,6 @@ func (m *Metrics) RecordAdapterRequest(labels metrics.AdapterLabels) {
 			adapterErrorLabel: string(err),
 		}).Inc()
 	}
-}
-func (m *Metrics) RecordHttpCounter() {
-	m.httpCounter.Inc()
 }
 
 func (m *Metrics) RecordRejectedBidsForBidder(Adapter openrtb_ext.BidderName) {

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -14,6 +14,7 @@ import (
 
 // Metrics defines the Prometheus metrics backing the MetricsEngine implementation.
 type Metrics struct {
+	OWMetrics
 	Registerer prometheus.Registerer
 	Gatherer   *prometheus.Registry
 
@@ -57,8 +58,6 @@ type Metrics struct {
 	adsCertSignTimer             prometheus.Histogram
 	bidderServerResponseTimer    prometheus.Histogram
 
-	requestsDuplicateBidIDCounter prometheus.Counter // total request having duplicate bid.id for given bidder
-
 	// Adapter Metrics
 	adapterBids                           *prometheus.CounterVec
 	adapterErrors                         *prometheus.CounterVec
@@ -76,25 +75,11 @@ type Metrics struct {
 	adapterBidResponseSecureMarkupError   *prometheus.CounterVec
 	adapterBidResponseSecureMarkupWarn    *prometheus.CounterVec
 
-	adapterDuplicateBidIDCounter *prometheus.CounterVec
-	adapterVideoBidDuration      *prometheus.HistogramVec
-	tlsHandhakeTimer             *prometheus.HistogramVec
+	tlsHandhakeTimer *prometheus.HistogramVec
 
 	// Syncer Metrics
 	syncerRequests *prometheus.CounterVec
 	syncerSets     *prometheus.CounterVec
-
-	// Rejected Bids
-	rejectedBids *prometheus.CounterVec
-	bids         *prometheus.CounterVec
-	vastVersion  *prometheus.CounterVec
-	vastTagType  *prometheus.CounterVec
-	//rejectedBids         *prometheus.CounterVec
-	accountRejectedBid   *prometheus.CounterVec
-	accountFloorsRequest *prometheus.CounterVec
-
-	//Dynamic Fetch Failure
-	dynamicFetchFailure *prometheus.CounterVec
 
 	// Account Metrics
 	accountRequests                       *prometheus.CounterVec
@@ -131,20 +116,7 @@ type Metrics struct {
 	moduleTimeouts        map[string]*prometheus.CounterVec
 	// Ad Pod Metrics
 
-	// podImpGenTimer indicates time taken by impression generator
-	// algorithm to generate impressions for given ad pod request
-	podImpGenTimer *prometheus.HistogramVec
-
-	// podImpGenTimer indicates time taken by combination generator
-	// algorithm to generate combination based on bid response and ad pod request
-	podCombGenTimer *prometheus.HistogramVec
-
-	// podCompExclTimer indicates time taken by compititve exclusion
-	// algorithm to generate final pod response based on bid response and ad pod request
-	podCompExclTimer *prometheus.HistogramVec
-
 	metricsDisabled config.DisabledMetrics
-
 	httpCounter prometheus.Counter
 }
 
@@ -225,6 +197,7 @@ func NewMetrics(cfg config.PrometheusMetrics, reg *prometheus.Registry, disabled
 	if reg == nil {
 		reg = prometheus.NewRegistry()
 	}
+	metrics.init(cfg, reg)
 	metrics.metricsDisabled = disabledMetrics
 
 	metrics.connectionsClosed = newCounterWithoutLabels(cfg, reg,
@@ -369,11 +342,6 @@ func NewMetrics(cfg config.PrometheusMetrics, reg *prometheus.Registry, disabled
 	// 	"tls_handshake_time",
 	// 	"Seconds to perform TLS Handshake",
 	// 	standardTimeBuckets)
-
-	metrics.bids = newCounter(cfg, reg,
-		"bids",
-		"Count of no of bids by publisher id, profile, bidder and deal",
-		[]string{pubIDLabel, profileLabel, bidderLabel, dealLabel})
 
 	metrics.privacyCCPA = newCounter(cfg, reg,
 		"privacy_ccpa",
@@ -555,36 +523,6 @@ func NewMetrics(cfg config.PrometheusMetrics, reg *prometheus.Registry, disabled
 		"Count of total requests to Prebid Server that have stored responses labled by account",
 		[]string{accountLabel})
 
-	metrics.accountRejectedBid = newCounter(cfg, reg,
-		"floors_account_rejected_bid_requests",
-		"Count of total requests to Prebid Server that have rejected bids due to floors enfocement labled by account",
-		[]string{accountLabel})
-
-	metrics.accountFloorsRequest = newCounter(cfg, reg,
-		"floors_account_requests",
-		"Count of total requests to Prebid Server that have non-zero imp.bidfloor labled by account",
-		[]string{accountLabel})
-
-	metrics.rejectedBids = newCounter(cfg, reg,
-		"rejected_bids",
-		"Count of rejected bids by publisher id, bidder and rejection reason code",
-		[]string{pubIDLabel, bidderLabel, codeLabel})
-
-	metrics.vastVersion = newCounter(cfg, reg,
-		"vast_version",
-		"Count of vast version by bidder and vast version",
-		[]string{adapterLabel, versionLabel})
-
-	metrics.vastTagType = newCounter(cfg, reg,
-		"vast_tag_type",
-		"Count of vast tag by bidder and vast tag type (Wrapper, InLine, URL, Unknown)",
-		[]string{bidderLabel, vastTagTypeLabel})
-
-	metrics.dynamicFetchFailure = newCounter(cfg, reg,
-		"floors_account_fetch_err",
-		"Count of failures in case of dynamic fetch labeled by account",
-		[]string{codeLabel, accountLabel})
-
 	metrics.adsCertSignTimer = newHistogram(cfg, reg,
 		"ads_cert_sign_time",
 		"Seconds to generate an AdsCert header",
@@ -651,44 +589,6 @@ func NewMetrics(cfg config.PrometheusMetrics, reg *prometheus.Registry, disabled
 
 	metrics.Registerer = prometheus.WrapRegistererWithPrefix(metricsPrefix, reg)
 	metrics.Registerer.MustRegister(promCollector.NewGoCollector())
-
-	metrics.adapterDuplicateBidIDCounter = newCounter(cfg, reg,
-		"duplicate_bid_ids",
-		"Number of collisions observed for given adaptor",
-		[]string{adapterLabel})
-
-	metrics.requestsDuplicateBidIDCounter = newCounterWithoutLabels(cfg, reg,
-		"requests_having_duplicate_bid_ids",
-		"Count of number of request where bid collision is detected.")
-
-	// adpod specific metrics
-	metrics.podImpGenTimer = newHistogramVec(cfg, reg,
-		"impr_gen",
-		"Time taken by Ad Pod Impression Generator in seconds", []string{podAlgorithm, podNoOfImpressions},
-		// 200 µS, 250 µS, 275 µS, 300 µS
-		//[]float64{0.000200000, 0.000250000, 0.000275000, 0.000300000})
-		// 100 µS, 200 µS, 300 µS, 400 µS, 500 µS,  600 µS,
-		[]float64{0.000100000, 0.000200000, 0.000300000, 0.000400000, 0.000500000, 0.000600000})
-
-	metrics.podCombGenTimer = newHistogramVec(cfg, reg,
-		"comb_gen",
-		"Time taken by Ad Pod Combination Generator in seconds", []string{podAlgorithm, podTotalCombinations},
-		// 200 µS, 250 µS, 275 µS, 300 µS
-		//[]float64{0.000200000, 0.000250000, 0.000275000, 0.000300000})
-		[]float64{0.000100000, 0.000200000, 0.000300000, 0.000400000, 0.000500000, 0.000600000})
-
-	metrics.podCompExclTimer = newHistogramVec(cfg, reg,
-		"comp_excl",
-		"Time taken by Ad Pod Compititve Exclusion in seconds", []string{podAlgorithm, podNoOfResponseBids},
-		// 200 µS, 250 µS, 275 µS, 300 µS
-		//[]float64{0.000200000, 0.000250000, 0.000275000, 0.000300000})
-		[]float64{0.000100000, 0.000200000, 0.000300000, 0.000400000, 0.000500000, 0.000600000})
-
-	metrics.adapterVideoBidDuration = newHistogramVec(cfg, reg,
-		"adapter_vidbid_dur",
-		"Video Ad durations returned by the bidder", []string{adapterLabel},
-		[]float64{4, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 120})
-
 	preloadLabelValues(&metrics, syncerKeys, moduleStageNames)
 
 	metrics.httpCounter = newHttpCounter(cfg, reg)
@@ -911,22 +811,6 @@ func (m *Metrics) RecordStoredResponse(pubId string) {
 	}
 }
 
-func (m *Metrics) RecordRejectedBidsForAccount(pubId string) {
-	if pubId != metrics.PublisherUnknown {
-		m.accountRejectedBid.With(prometheus.Labels{
-			accountLabel: pubId,
-		}).Inc()
-	}
-}
-
-func (m *Metrics) RecordFloorsRequestForAccount(pubId string) {
-	if pubId != metrics.PublisherUnknown {
-		m.accountFloorsRequest.With(prometheus.Labels{
-			accountLabel: pubId,
-		}).Inc()
-	}
-}
-
 func (m *Metrics) RecordImps(labels metrics.ImpLabels) {
 	m.impressions.With(prometheus.Labels{
 		isBannerLabel: strconv.FormatBool(labels.BannerImps),
@@ -1016,20 +900,14 @@ func (m *Metrics) RecordAdapterRequest(labels metrics.AdapterLabels) {
 		}).Inc()
 	}
 }
+func (m *Metrics) RecordHttpCounter() {
+	m.httpCounter.Inc()
+}
 
 func (m *Metrics) RecordRejectedBidsForBidder(Adapter openrtb_ext.BidderName) {
 	if m.rejectedBids != nil {
 		m.rejectedBids.With(prometheus.Labels{
 			adapterLabel: string(Adapter),
-		}).Inc()
-	}
-}
-
-func (m *Metrics) RecordDynamicFetchFailure(pubId, code string) {
-	if pubId != metrics.PublisherUnknown {
-		m.dynamicFetchFailure.With(prometheus.Labels{
-			accountLabel: pubId,
-			codeLabel:    code,
 		}).Inc()
 	}
 }

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -117,7 +117,7 @@ type Metrics struct {
 	// Ad Pod Metrics
 
 	metricsDisabled config.DisabledMetrics
-	httpCounter prometheus.Counter
+	httpCounter     prometheus.Counter
 }
 
 const (

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -88,7 +88,7 @@ type Metrics struct {
 	rejectedBids *prometheus.CounterVec
 	bids         *prometheus.CounterVec
 	vastVersion  *prometheus.CounterVec
-	vastTag      *prometheus.CounterVec
+	vastTagType  *prometheus.CounterVec
 	//rejectedBids         *prometheus.CounterVec
 	accountRejectedBid   *prometheus.CounterVec
 	accountFloorsRequest *prometheus.CounterVec
@@ -575,10 +575,10 @@ func NewMetrics(cfg config.PrometheusMetrics, reg *prometheus.Registry, disabled
 		"Count of vast version by bidder and vast version",
 		[]string{adapterLabel, versionLabel})
 
-	metrics.vastTag = newCounter(cfg, reg,
+	metrics.vastTagType = newCounter(cfg, reg,
 		"vast_tag_type",
 		"Count of vast tag by bidder and vast tag type (Wrapper, InLine, URL, Unknown)",
-		[]string{bidderLabel, vastTagLabel})
+		[]string{bidderLabel, vastTagTypeLabel})
 
 	metrics.dynamicFetchFailure = newCounter(cfg, reg,
 		"floors_account_fetch_err",

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -576,8 +576,8 @@ func NewMetrics(cfg config.PrometheusMetrics, reg *prometheus.Registry, disabled
 		[]string{adapterLabel, versionLabel})
 
 	metrics.vastTag = newCounter(cfg, reg,
-		"vast_tag",
-		"Count of vast tag by bidder and vast tag",
+		"vast_tag_type",
+		"Count of vast tag by bidder and vast tag type (Wrapper, InLine, URL, Unknown)",
 		[]string{bidderLabel, vastTagLabel})
 
 	metrics.dynamicFetchFailure = newCounter(cfg, reg,

--- a/metrics/prometheus/prometheus_ow.go
+++ b/metrics/prometheus/prometheus_ow.go
@@ -10,12 +10,12 @@ import (
 )
 
 const (
-	pubIDLabel   = "pubid"
-	bidderLabel  = "bidder"
-	codeLabel    = "code"
-	profileLabel = "profileid"
-	dealLabel    = "deal"
-	vastTagLabel = "vasttag"
+	pubIDLabel       = "pubid"
+	bidderLabel      = "bidder"
+	codeLabel        = "code"
+	profileLabel     = "profileid"
+	dealLabel        = "deal"
+	vastTagTypeLabel = "type"
 )
 
 func newHttpCounter(cfg config.PrometheusMetrics, registry *prometheus.Registry) prometheus.Counter {
@@ -122,10 +122,10 @@ func (m *Metrics) RecordHttpCounter() {
 	m.httpCounter.Inc()
 }
 
-// RecordVastTag record the count of vast tags labeled by bidder and vast tag
-func (m *Metrics) RecordVastTag(bidder, vastTag string) {
-	m.vastTag.With(prometheus.Labels{
-		bidderLabel:  bidder,
-		vastTagLabel: vastTag,
+// RecordVASTTagType record the count of vast tags labeled by bidder and vast tag
+func (m *Metrics) RecordVASTTagType(bidder, vastTagType string) {
+	m.vastTagType.With(prometheus.Labels{
+		bidderLabel:      bidder,
+		vastTagTypeLabel: vastTagType,
 	}).Inc()
 }

--- a/metrics/prometheus/prometheus_ow.go
+++ b/metrics/prometheus/prometheus_ow.go
@@ -18,6 +18,35 @@ const (
 	vastTagTypeLabel = "type"
 )
 
+type OWMetrics struct {
+	vastTagType *prometheus.CounterVec
+	// Rejected Bids
+	rejectedBids *prometheus.CounterVec
+	bids         *prometheus.CounterVec
+	vastVersion  *prometheus.CounterVec
+	//rejectedBids         *prometheus.CounterVec
+	accountRejectedBid   *prometheus.CounterVec
+	accountFloorsRequest *prometheus.CounterVec
+
+	//Dynamic Fetch Failure
+	dynamicFetchFailure           *prometheus.CounterVec
+	adapterDuplicateBidIDCounter  *prometheus.CounterVec
+	requestsDuplicateBidIDCounter prometheus.Counter // total request having duplicate bid.id for given bidder
+	adapterVideoBidDuration       *prometheus.HistogramVec
+
+	// podImpGenTimer indicates time taken by impression generator
+	// algorithm to generate impressions for given ad pod request
+	podImpGenTimer *prometheus.HistogramVec
+
+	// podImpGenTimer indicates time taken by combination generator
+	// algorithm to generate combination based on bid response and ad pod request
+	podCombGenTimer *prometheus.HistogramVec
+
+	// podCompExclTimer indicates time taken by compititve exclusion
+	// algorithm to generate final pod response based on bid response and ad pod request
+	podCompExclTimer *prometheus.HistogramVec
+}
+
 func newHttpCounter(cfg config.PrometheusMetrics, registry *prometheus.Registry) prometheus.Counter {
 	httpCounter := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "http_requests_total",
@@ -31,7 +60,7 @@ func newHttpCounter(cfg config.PrometheusMetrics, registry *prometheus.Registry)
 // gives the bid response with multiple bids containing  same bid.ID
 // ensure collisions value is greater than 1. This function will not give any error
 // if collisions = 1 is passed
-func (m *Metrics) RecordAdapterDuplicateBidID(adaptor string, collisions int) {
+func (m *OWMetrics) RecordAdapterDuplicateBidID(adaptor string, collisions int) {
 	m.adapterDuplicateBidIDCounter.With(prometheus.Labels{
 		adapterLabel: adaptor,
 	}).Add(float64(collisions))
@@ -39,7 +68,7 @@ func (m *Metrics) RecordAdapterDuplicateBidID(adaptor string, collisions int) {
 
 // RecordRequestHavingDuplicateBidID keeps count of request when duplicate bid.id is
 // detected in partner's response
-func (m *Metrics) RecordRequestHavingDuplicateBidID() {
+func (m *OWMetrics) RecordRequestHavingDuplicateBidID() {
 	m.requestsDuplicateBidIDCounter.Inc()
 }
 
@@ -67,32 +96,32 @@ func recordAlgoTime(timer *prometheus.HistogramVec, labels metrics.PodLabels, el
 
 // RecordPodImpGenTime records number of impressions generated and time taken
 // by underneath algorithm to generate them
-func (m *Metrics) RecordPodImpGenTime(labels metrics.PodLabels, start time.Time) {
+func (m *OWMetrics) RecordPodImpGenTime(labels metrics.PodLabels, start time.Time) {
 	elapsedTime := time.Since(start)
 	recordAlgoTime(m.podImpGenTimer, labels, elapsedTime)
 }
 
 // RecordPodCombGenTime records number of combinations generated and time taken
 // by underneath algorithm to generate them
-func (m *Metrics) RecordPodCombGenTime(labels metrics.PodLabels, elapsedTime time.Duration) {
+func (m *OWMetrics) RecordPodCombGenTime(labels metrics.PodLabels, elapsedTime time.Duration) {
 	recordAlgoTime(m.podCombGenTimer, labels, elapsedTime)
 }
 
 // RecordPodCompititveExclusionTime records number of combinations comsumed for forming
 // final ad pod response and time taken by underneath algorithm to generate them
-func (m *Metrics) RecordPodCompititveExclusionTime(labels metrics.PodLabels, elapsedTime time.Duration) {
+func (m *OWMetrics) RecordPodCompititveExclusionTime(labels metrics.PodLabels, elapsedTime time.Duration) {
 	recordAlgoTime(m.podCompExclTimer, labels, elapsedTime)
 }
 
 // RecordAdapterVideoBidDuration records actual ad duration (>0) returned by the bidder
-func (m *Metrics) RecordAdapterVideoBidDuration(labels metrics.AdapterLabels, videoBidDuration int) {
+func (m *OWMetrics) RecordAdapterVideoBidDuration(labels metrics.AdapterLabels, videoBidDuration int) {
 	if videoBidDuration > 0 {
 		m.adapterVideoBidDuration.With(prometheus.Labels{adapterLabel: string(labels.Adapter)}).Observe(float64(videoBidDuration))
 	}
 }
 
 // RecordRejectedBids records rejected bids labeled by pubid, bidder and reason code
-func (m *Metrics) RecordRejectedBids(pubid, biddder, code string) {
+func (m *OWMetrics) RecordRejectedBids(pubid, biddder, code string) {
 	m.rejectedBids.With(prometheus.Labels{
 		pubIDLabel:  pubid,
 		bidderLabel: biddder,
@@ -101,7 +130,7 @@ func (m *Metrics) RecordRejectedBids(pubid, biddder, code string) {
 }
 
 // RecordBids records bids labeled by pubid, profileid, bidder and deal
-func (m *Metrics) RecordBids(pubid, profileid, biddder, deal string) {
+func (m *OWMetrics) RecordBids(pubid, profileid, biddder, deal string) {
 	m.bids.With(prometheus.Labels{
 		pubIDLabel:   pubid,
 		profileLabel: profileid,
@@ -111,21 +140,115 @@ func (m *Metrics) RecordBids(pubid, profileid, biddder, deal string) {
 }
 
 // RecordVastVersion record the count of vast version labelled by bidder and vast version
-func (m *Metrics) RecordVastVersion(coreBiddder, vastVersion string) {
+func (m *OWMetrics) RecordVastVersion(coreBiddder, vastVersion string) {
 	m.vastVersion.With(prometheus.Labels{
 		adapterLabel: coreBiddder,
 		versionLabel: vastVersion,
 	}).Inc()
 }
 
-func (m *Metrics) RecordHttpCounter() {
-	m.httpCounter.Inc()
-}
-
 // RecordVASTTagType record the count of vast tags labeled by bidder and vast tag
-func (m *Metrics) RecordVASTTagType(bidder, vastTagType string) {
+func (m *OWMetrics) RecordVASTTagType(bidder, vastTagType string) {
 	m.vastTagType.With(prometheus.Labels{
 		bidderLabel:      bidder,
 		vastTagTypeLabel: vastTagType,
 	}).Inc()
+}
+func (m *Metrics) RecordRejectedBidsForAccount(pubId string) {
+	if pubId != metrics.PublisherUnknown {
+		m.accountRejectedBid.With(prometheus.Labels{
+			accountLabel: pubId,
+		}).Inc()
+	}
+}
+
+func (m *Metrics) RecordFloorsRequestForAccount(pubId string) {
+	if pubId != metrics.PublisherUnknown {
+		m.accountFloorsRequest.With(prometheus.Labels{
+			accountLabel: pubId,
+		}).Inc()
+	}
+}
+func (m *Metrics) RecordDynamicFetchFailure(pubId, code string) {
+	if pubId != metrics.PublisherUnknown {
+		m.dynamicFetchFailure.With(prometheus.Labels{
+			accountLabel: pubId,
+			codeLabel:    code,
+		}).Inc()
+	}
+}
+
+func (m *OWMetrics) init(cfg config.PrometheusMetrics, reg *prometheus.Registry) {
+	m.rejectedBids = newCounter(cfg, reg,
+		"rejected_bids",
+		"Count of rejected bids by publisher id, bidder and rejection reason code",
+		[]string{pubIDLabel, bidderLabel, codeLabel})
+
+	m.vastVersion = newCounter(cfg, reg,
+		"vast_version",
+		"Count of vast version by bidder and vast version",
+		[]string{adapterLabel, versionLabel})
+
+	m.vastTagType = newCounter(cfg, reg,
+		"vast_tag_type",
+		"Count of vast tag by bidder and vast tag type (Wrapper, InLine, URL, Unknown)",
+		[]string{bidderLabel, vastTagTypeLabel})
+
+	m.dynamicFetchFailure = newCounter(cfg, reg,
+		"floors_account_fetch_err",
+		"Count of failures in case of dynamic fetch labeled by account",
+		[]string{codeLabel, accountLabel})
+
+	m.adapterDuplicateBidIDCounter = newCounter(cfg, reg,
+		"duplicate_bid_ids",
+		"Number of collisions observed for given adaptor",
+		[]string{adapterLabel})
+
+	m.requestsDuplicateBidIDCounter = newCounterWithoutLabels(cfg, reg,
+		"requests_having_duplicate_bid_ids",
+		"Count of number of request where bid collision is detected.")
+
+	m.adapterVideoBidDuration = newHistogramVec(cfg, reg,
+		"adapter_vidbid_dur",
+		"Video Ad durations returned by the bidder", []string{adapterLabel},
+		[]float64{4, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 120})
+
+	m.bids = newCounter(cfg, reg,
+		"bids",
+		"Count of no of bids by publisher id, profile, bidder and deal",
+		[]string{pubIDLabel, profileLabel, bidderLabel, dealLabel})
+
+	m.accountRejectedBid = newCounter(cfg, reg,
+		"floors_account_rejected_bid_requests",
+		"Count of total requests to Prebid Server that have rejected bids due to floors enfocement labled by account",
+		[]string{accountLabel})
+
+	m.accountFloorsRequest = newCounter(cfg, reg,
+		"floors_account_requests",
+		"Count of total requests to Prebid Server that have non-zero imp.bidfloor labled by account",
+		[]string{accountLabel})
+
+	// adpod specific metrics
+	m.podImpGenTimer = newHistogramVec(cfg, reg,
+		"impr_gen",
+		"Time taken by Ad Pod Impression Generator in seconds", []string{podAlgorithm, podNoOfImpressions},
+		// 200 µS, 250 µS, 275 µS, 300 µS
+		//[]float64{0.000200000, 0.000250000, 0.000275000, 0.000300000})
+		// 100 µS, 200 µS, 300 µS, 400 µS, 500 µS,  600 µS,
+		[]float64{0.000100000, 0.000200000, 0.000300000, 0.000400000, 0.000500000, 0.000600000})
+
+	m.podCombGenTimer = newHistogramVec(cfg, reg,
+		"comb_gen",
+		"Time taken by Ad Pod Combination Generator in seconds", []string{podAlgorithm, podTotalCombinations},
+		// 200 µS, 250 µS, 275 µS, 300 µS
+		//[]float64{0.000200000, 0.000250000, 0.000275000, 0.000300000})
+		[]float64{0.000100000, 0.000200000, 0.000300000, 0.000400000, 0.000500000, 0.000600000})
+
+	m.podCompExclTimer = newHistogramVec(cfg, reg,
+		"comp_excl",
+		"Time taken by Ad Pod Compititve Exclusion in seconds", []string{podAlgorithm, podNoOfResponseBids},
+		// 200 µS, 250 µS, 275 µS, 300 µS
+		//[]float64{0.000200000, 0.000250000, 0.000275000, 0.000300000})
+		[]float64{0.000100000, 0.000200000, 0.000300000, 0.000400000, 0.000500000, 0.000600000})
+
 }

--- a/metrics/prometheus/prometheus_ow.go
+++ b/metrics/prometheus/prometheus_ow.go
@@ -15,6 +15,7 @@ const (
 	codeLabel    = "code"
 	profileLabel = "profileid"
 	dealLabel    = "deal"
+	vastTagLabel = "vasttag"
 )
 
 func newHttpCounter(cfg config.PrometheusMetrics, registry *prometheus.Registry) prometheus.Counter {
@@ -119,4 +120,12 @@ func (m *Metrics) RecordVastVersion(coreBiddder, vastVersion string) {
 
 func (m *Metrics) RecordHttpCounter() {
 	m.httpCounter.Inc()
+}
+
+// RecordVastTag record the count of vast tags labeled by bidder and vast tag
+func (m *Metrics) RecordVastTag(bidder, vastTag string) {
+	m.vastTag.With(prometheus.Labels{
+		bidderLabel:  bidder,
+		vastTagLabel: vastTag,
+	}).Inc()
 }

--- a/metrics/prometheus/prometheus_ow.go
+++ b/metrics/prometheus/prometheus_ow.go
@@ -45,6 +45,7 @@ type OWMetrics struct {
 	// podCompExclTimer indicates time taken by compititve exclusion
 	// algorithm to generate final pod response based on bid response and ad pod request
 	podCompExclTimer *prometheus.HistogramVec
+	httpCounter      prometheus.Counter
 }
 
 func newHttpCounter(cfg config.PrometheusMetrics, registry *prometheus.Registry) prometheus.Counter {
@@ -178,7 +179,12 @@ func (m *Metrics) RecordDynamicFetchFailure(pubId, code string) {
 	}
 }
 
+func (m *Metrics) RecordHttpCounter() {
+	m.httpCounter.Inc()
+}
+
 func (m *OWMetrics) init(cfg config.PrometheusMetrics, reg *prometheus.Registry) {
+	m.httpCounter = newHttpCounter(cfg, reg)
 	m.rejectedBids = newCounter(cfg, reg,
 		"rejected_bids",
 		"Count of rejected bids by publisher id, bidder and rejection reason code",

--- a/metrics/prometheus/prometheus_ow_test.go
+++ b/metrics/prometheus/prometheus_ow_test.go
@@ -129,39 +129,39 @@ func TestRecordVastVersion(t *testing.T) {
 }
 
 func TestRecordVASTTagType(t *testing.T) {
-	type testIn struct {
-		bidder, vastTag string
+	type args struct {
+		bidder, vastTagType string
 	}
-	type testOut struct {
+	type want struct {
 		expCount int
 	}
-	testCases := []struct {
+	tests := []struct {
 		description string
-		in          testIn
-		out         testOut
+		args        args
+		want        want
 	}{
 		{
-			description: "record vast tag",
-			in: testIn{
-				bidder:  "bidder",
-				vastTag: "Wrapper",
+			description: "record_vast_tag",
+			args: args{
+				bidder:      "bidder",
+				vastTagType: "Wrapper",
 			},
-			out: testOut{
+			want: want{
 				expCount: 1,
 			},
 		},
 	}
-	for _, test := range testCases {
+	for _, tt := range tests {
 		pm := createMetricsForTesting()
-		pm.RecordVASTTagType(test.in.bidder, test.in.vastTag)
+		pm.RecordVASTTagType(tt.args.bidder, tt.args.vastTagType)
 		assertCounterVecValue(t,
 			"",
 			"record vastTag",
 			pm.vastTagType,
-			float64(test.out.expCount),
+			float64(tt.want.expCount),
 			prometheus.Labels{
-				bidderLabel:      test.in.bidder,
-				vastTagTypeLabel: test.in.vastTag,
+				bidderLabel:      tt.args.bidder,
+				vastTagTypeLabel: tt.args.vastTagType,
 			})
 	}
 }

--- a/metrics/prometheus/prometheus_ow_test.go
+++ b/metrics/prometheus/prometheus_ow_test.go
@@ -127,3 +127,41 @@ func TestRecordVastVersion(t *testing.T) {
 			})
 	}
 }
+
+func TestRecordVastTag(t *testing.T) {
+	type testIn struct {
+		bidder, vastTag string
+	}
+	type testOut struct {
+		expCount int
+	}
+	testCases := []struct {
+		description string
+		in          testIn
+		out         testOut
+	}{
+		{
+			description: "record vast tag",
+			in: testIn{
+				bidder:  "bidder",
+				vastTag: "Wrapper",
+			},
+			out: testOut{
+				expCount: 1,
+			},
+		},
+	}
+	for _, test := range testCases {
+		pm := createMetricsForTesting()
+		pm.RecordVastTag(test.in.bidder, test.in.vastTag)
+		assertCounterVecValue(t,
+			"",
+			"record vastTag",
+			pm.vastTag,
+			float64(test.out.expCount),
+			prometheus.Labels{
+				bidderLabel:  test.in.bidder,
+				vastTagLabel: test.in.vastTag,
+			})
+	}
+}

--- a/metrics/prometheus/prometheus_ow_test.go
+++ b/metrics/prometheus/prometheus_ow_test.go
@@ -128,7 +128,7 @@ func TestRecordVastVersion(t *testing.T) {
 	}
 }
 
-func TestRecordVastTag(t *testing.T) {
+func TestRecordVASTTagType(t *testing.T) {
 	type testIn struct {
 		bidder, vastTag string
 	}
@@ -153,15 +153,15 @@ func TestRecordVastTag(t *testing.T) {
 	}
 	for _, test := range testCases {
 		pm := createMetricsForTesting()
-		pm.RecordVastTag(test.in.bidder, test.in.vastTag)
+		pm.RecordVASTTagType(test.in.bidder, test.in.vastTag)
 		assertCounterVecValue(t,
 			"",
 			"record vastTag",
-			pm.vastTag,
+			pm.vastTagType,
 			float64(test.out.expCount),
 			prometheus.Labels{
-				bidderLabel:  test.in.bidder,
-				vastTagLabel: test.in.vastTag,
+				bidderLabel:      test.in.bidder,
+				vastTagTypeLabel: test.in.vastTag,
 			})
 	}
 }

--- a/metrics/prometheus/prometheus_ow_test.go
+++ b/metrics/prometheus/prometheus_ow_test.go
@@ -14,12 +14,12 @@ func TestRecordRejectedBids(t *testing.T) {
 		expCount int
 	}
 	testCases := []struct {
-		description string
-		in          testIn
-		out         testOut
+		name string
+		in   testIn
+		out  testOut
 	}{
 		{
-			description: "record rejected bids",
+			name: "record rejected bids",
 			in: testIn{
 				pubid:  "1010",
 				bidder: "bidder",
@@ -55,12 +55,12 @@ func TestRecordBids(t *testing.T) {
 		expCount int
 	}
 	testCases := []struct {
-		description string
-		in          testIn
-		out         testOut
+		name string
+		in   testIn
+		out  testOut
 	}{
 		{
-			description: "record bids",
+			name: "record bids",
 			in: testIn{
 				pubid:     "1010",
 				bidder:    "bidder",
@@ -98,12 +98,12 @@ func TestRecordVastVersion(t *testing.T) {
 		expCount int
 	}
 	testCases := []struct {
-		description string
-		in          testIn
-		out         testOut
+		name string
+		in   testIn
+		out  testOut
 	}{
 		{
-			description: "record vast version",
+			name: "record vast version",
 			in: testIn{
 				coreBidder:  "bidder",
 				vastVersion: "2.0",
@@ -136,12 +136,12 @@ func TestRecordVASTTagType(t *testing.T) {
 		expCount int
 	}
 	tests := []struct {
-		description string
-		args        args
-		want        want
+		name string
+		args args
+		want want
 	}{
 		{
-			description: "record_vast_tag",
+			name: "record_vast_tag",
 			args: args{
 				bidder:      "bidder",
 				vastTagType: "Wrapper",
@@ -152,16 +152,19 @@ func TestRecordVASTTagType(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		pm := createMetricsForTesting()
-		pm.RecordVASTTagType(tt.args.bidder, tt.args.vastTagType)
-		assertCounterVecValue(t,
-			"",
-			"record vastTag",
-			pm.vastTagType,
-			float64(tt.want.expCount),
-			prometheus.Labels{
-				bidderLabel:      tt.args.bidder,
-				vastTagTypeLabel: tt.args.vastTagType,
-			})
+		t.Run(tt.name, func(t *testing.T) {
+
+			pm := createMetricsForTesting()
+			pm.RecordVASTTagType(tt.args.bidder, tt.args.vastTagType)
+			assertCounterVecValue(t,
+				"",
+				"record vastTag",
+				pm.vastTagType,
+				float64(tt.want.expCount),
+				prometheus.Labels{
+					bidderLabel:      tt.args.bidder,
+					vastTagTypeLabel: tt.args.vastTagType,
+				})
+		})
 	}
 }


### PR DESCRIPTION


# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
