### PR TITLE
Fix: Single colon in BidId causing inconsistent split

### DIFF
--- a/modules/pubmatic/openwrap/utils/bid.go
+++ b/modules/pubmatic/openwrap/utils/bid.go
@@ -6,7 +6,7 @@ import (
 	"github.com/prebid/prebid-server/modules/pubmatic/openwrap/models"
 )
 
-var bidIDRegx = regexp.MustCompile("[" + models.BidIdSeparator + "]")
+var bidIDRegx = regexp.MustCompile("(" + models.BidIdSeparator + ")")
 
 func GetOriginalBidId(bidID string) string {
 	return bidIDRegx.Split(bidID, -1)[0]

--- a/modules/pubmatic/openwrap/utils/bid_test.go
+++ b/modules/pubmatic/openwrap/utils/bid_test.go
@@ -48,6 +48,20 @@ func TestGetOriginalBidId(t *testing.T) {
 			},
 			want: "original-bid",
 		},
+		{
+			name: "BidId with single colon in origin Id",
+			args: args{
+				bidId: "original-bid:2::generated-bid",
+			},
+			want: "original-bid:2",
+		},
+		{
+			name: "BidId with single colon in generated Id",
+			args: args{
+				bidId: "original-bid:2::generated-bid:3",
+			},
+			want: "original-bid:2",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
