### PR TITLE
OTT-1441: Moved random number generation  from VAST un-wrap module to OW server 

### DIFF
--- a/modules/pubmatic/vastunwrap/entryhook.go
+++ b/modules/pubmatic/vastunwrap/entryhook.go
@@ -2,7 +2,6 @@ package vastunwrap
 
 import (
 	"context"
-	"math/rand"
 	"runtime/debug"
 
 	"github.com/golang/glog"
@@ -13,10 +12,6 @@ import (
 func getVastUnwrapperEnable(ctx context.Context, field string) bool {
 	vastEnableUnwrapper, _ := ctx.Value(field).(string)
 	return vastEnableUnwrapper == "1"
-}
-
-var getRandomNumber = func() int {
-	return rand.Intn(100)
 }
 
 func handleEntrypointHook(
@@ -31,7 +26,7 @@ func handleEntrypointHook(
 	}()
 	result := hookstage.HookResult[hookstage.EntrypointPayload]{}
 	vastRequestContext := models.RequestCtx{
-		VastUnwrapEnabled: getVastUnwrapperEnable(payload.Request.Context(), VastUnwrapEnabled) && getRandomNumber() < config.TrafficPercentage,
+		VastUnwrapEnabled: getVastUnwrapperEnable(payload.Request.Context(), VastUnwrapEnabled),
 	}
 	result.ModuleContext = make(hookstage.ModuleContext)
 	result.ModuleContext[RequestContext] = vastRequestContext

--- a/modules/pubmatic/vastunwrap/entryhook_test.go
+++ b/modules/pubmatic/vastunwrap/entryhook_test.go
@@ -39,7 +39,7 @@ func TestHandleEntrypointHook(t *testing.T) {
 			want: hookstage.HookResult[hookstage.EntrypointPayload]{ModuleContext: hookstage.ModuleContext{"rctx": models.RequestCtx{VastUnwrapEnabled: false}}},
 		},
 		{
-			name: "Enable Vast Unwrapper with random number less than traffic percentage",
+			name: "Enable Vast Unwrapper",
 			args: args{
 				payload: hookstage.EntrypointPayload{
 					Request: func() *http.Request {
@@ -55,48 +55,9 @@ func TestHandleEntrypointHook(t *testing.T) {
 			randomNum: 1,
 			want:      hookstage.HookResult[hookstage.EntrypointPayload]{ModuleContext: hookstage.ModuleContext{"rctx": models.RequestCtx{VastUnwrapEnabled: true}}},
 		},
-		{
-			name: "Enable Vast Unwrapper with random number equal to traffic percenatge",
-			args: args{
-				payload: hookstage.EntrypointPayload{
-					Request: func() *http.Request {
-						ctx := context.WithValue(context.Background(), VastUnwrapEnabled, "1")
-						r, _ := http.NewRequestWithContext(ctx, "", "", nil)
-						return r
-					}(),
-				},
-				config: VastUnwrapModule{
-					TrafficPercentage: 2,
-				},
-			},
-			randomNum: 2,
-			want:      hookstage.HookResult[hookstage.EntrypointPayload]{ModuleContext: hookstage.ModuleContext{"rctx": models.RequestCtx{VastUnwrapEnabled: false}}},
-		},
-		{
-			name: "Enable Vast Unwrapper with random number greater than traffic percenatge",
-			args: args{
-				payload: hookstage.EntrypointPayload{
-					Request: func() *http.Request {
-						ctx := context.WithValue(context.Background(), VastUnwrapEnabled, "1")
-						r, _ := http.NewRequestWithContext(ctx, "", "", nil)
-						return r
-					}(),
-				},
-				config: VastUnwrapModule{
-					TrafficPercentage: 2,
-				},
-			},
-			randomNum: 5,
-			want:      hookstage.HookResult[hookstage.EntrypointPayload]{ModuleContext: hookstage.ModuleContext{"rctx": models.RequestCtx{VastUnwrapEnabled: false}}},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			oldRandomNumberGen := getRandomNumber
-			getRandomNumber = func() int { return tt.randomNum }
-			defer func() {
-				getRandomNumber = oldRandomNumberGen
-			}()
 			got, _ := handleEntrypointHook(nil, hookstage.ModuleInvocationContext{}, tt.args.payload, tt.args.config)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("handleEntrypointHook() = %v, want %v", got, tt.want)

--- a/modules/pubmatic/vastunwrap/module_test.go
+++ b/modules/pubmatic/vastunwrap/module_test.go
@@ -87,11 +87,6 @@ func TestVastUnwrapModuleHandleEntrypointHook(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			oldRandomNumberGen := getRandomNumber
-			getRandomNumber = func() int { return 1 }
-			defer func() {
-				getRandomNumber = oldRandomNumberGen
-			}()
 			m := VastUnwrapModule{
 				Cfg:               tt.fields.cfg.Cfg,
 				Enabled:           tt.fields.cfg.Enabled,


### PR DESCRIPTION


# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
