### PR TITLE
OTT-1431: Added publisher level stats for vast-wrapper count and response time

### DIFF
--- a/modules/pubmatic/vastunwrap/entryhook.go
+++ b/modules/pubmatic/vastunwrap/entryhook.go
@@ -33,6 +33,10 @@ func handleEntrypointHook(
 	vastRequestContext := models.RequestCtx{
 		VastUnwrapEnabled: getVastUnwrapperEnable(payload.Request.Context(), VastUnwrapEnabled) && getRandomNumber() < config.TrafficPercentage,
 	}
+
+	if !vastRequestContext.VastUnwrapEnabled {
+		vastRequestContext.VastUnwrapStatsEnabled = getRandomNumber() < config.StatTrafficPercentage
+	}
 	result.ModuleContext = make(hookstage.ModuleContext)
 	result.ModuleContext[RequestContext] = vastRequestContext
 	return result, nil

--- a/modules/pubmatic/vastunwrap/hook_raw_bidder_response.go
+++ b/modules/pubmatic/vastunwrap/hook_raw_bidder_response.go
@@ -19,26 +19,38 @@ func (m VastUnwrapModule) handleRawBidderResponseHook(
 		result.DebugMessages = append(result.DebugMessages, "error: request-ctx not found in handleRawBidderResponseHook()")
 		return result, nil
 	}
-	if !vastRequestContext.VastUnwrapEnabled {
+	if !vastRequestContext.VastUnwrapEnabled && !vastRequestContext.VastUnwrapStatsEnabled {
 		result.DebugMessages = append(result.DebugMessages, "error: vast unwrap flag is not enabled in handleRawBidderResponseHook()")
 		return result, nil
 	}
 	defer func() {
 		miCtx.ModuleContext[RequestContext] = vastRequestContext
 	}()
-	wg := new(sync.WaitGroup)
-	for _, bid := range payload.Bids {
-		if string(bid.BidType) == MediaTypeVideo {
-			wg.Add(1)
-			go func(bid *adapters.TypedBid) {
-				defer wg.Done()
-				m.doUnwrapandUpdateBid(bid, vastRequestContext.UA, unwrapURL, miCtx.AccountID, payload.Bidder)
-			}(bid)
+
+	// Below code collects stats only
+	if vastRequestContext.VastUnwrapStatsEnabled {
+		for _, bid := range payload.Bids {
+			if string(bid.BidType) == MediaTypeVideo {
+				go func(bid *adapters.TypedBid) {
+					m.doUnwrapandUpdateBid(vastRequestContext.VastUnwrapStatsEnabled, bid, vastRequestContext.UA, unwrapURL, miCtx.AccountID, payload.Bidder)
+				}(bid)
+			}
 		}
+	} else {
+		wg := new(sync.WaitGroup)
+		for _, bid := range payload.Bids {
+			if string(bid.BidType) == MediaTypeVideo {
+				wg.Add(1)
+				go func(bid *adapters.TypedBid) {
+					defer wg.Done()
+					m.doUnwrapandUpdateBid(vastRequestContext.VastUnwrapStatsEnabled, bid, vastRequestContext.UA, unwrapURL, miCtx.AccountID, payload.Bidder)
+				}(bid)
+			}
+		}
+		wg.Wait()
+		changeSet := hookstage.ChangeSet[hookstage.RawBidderResponsePayload]{}
+		changeSet.RawBidderResponse().Bids().Update(payload.Bids)
+		result.ChangeSet = changeSet
 	}
-	wg.Wait()
-	changeSet := hookstage.ChangeSet[hookstage.RawBidderResponsePayload]{}
-	changeSet.RawBidderResponse().Bids().Update(payload.Bids)
-	result.ChangeSet = changeSet
 	return result, nil
 }

--- a/modules/pubmatic/vastunwrap/hook_raw_bidder_response_test.go
+++ b/modules/pubmatic/vastunwrap/hook_raw_bidder_response_test.go
@@ -71,6 +71,42 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 			wantErr:    false,
 		},
 		{
+			name: "Set Vast Unwrapper to false in request context with type video, stats enabled true",
+			args: args{
+				module: VastUnWrapModule,
+				payload: hookstage.RawBidderResponsePayload{
+					Bids: []*adapters.TypedBid{
+						{
+							Bid: &openrtb2.Bid{
+								ID:    "Bid-123",
+								ImpID: fmt.Sprintf("div-adunit-%d", 123),
+								Price: 2.1,
+								AdM:   vastXMLAdM,
+								CrID:  "Cr-234",
+								W:     100,
+								H:     50,
+							},
+							BidType: "video",
+						}},
+					Bidder: "pubmatic",
+				},
+				moduleInvocationCtx: hookstage.ModuleInvocationContext{AccountID: "5890", ModuleContext: hookstage.ModuleContext{"rctx": models.RequestCtx{VastUnwrapEnabled: false, VastUnwrapStatsEnabled: true}}},
+			},
+			wantResult: hookstage.HookResult[hookstage.RawBidderResponsePayload]{Reject: false},
+			setup: func() {
+				mockMetricsEngine.EXPECT().RecordRequestStatus("5890", "pubmatic", "0").AnyTimes()
+				mockMetricsEngine.EXPECT().RecordWrapperCount("5890", "pubmatic", "1").AnyTimes()
+				mockMetricsEngine.EXPECT().RecordRequestTime("5890", "pubmatic", gomock.Any()).AnyTimes()
+			},
+			unwrapRequest: func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Add("unwrap-status", "0")
+				w.Header().Add("unwrap-count", "1")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(inlineXMLAdM))
+			},
+			wantErr: false,
+		},
+		{
 			name: "Set Vast Unwrapper to true in request context with invalid vast xml",
 			args: args{
 				module: VastUnWrapModule,
@@ -96,8 +132,8 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 			},
 			wantResult: hookstage.HookResult[hookstage.RawBidderResponsePayload]{Reject: false},
 			setup: func() {
-				mockMetricsEngine.EXPECT().RecordRequestStatus("pubmatic", "1").AnyTimes()
-				mockMetricsEngine.EXPECT().RecordRequestTime("pubmatic", gomock.Any()).AnyTimes()
+				mockMetricsEngine.EXPECT().RecordRequestStatus("5890", "pubmatic", "1").AnyTimes()
+				mockMetricsEngine.EXPECT().RecordRequestTime("5890", "pubmatic", gomock.Any()).AnyTimes()
 			},
 			unwrapRequest: func(w http.ResponseWriter, req *http.Request) {
 				w.Header().Add("unwrap-status", "1")
@@ -132,9 +168,9 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 			},
 			wantResult: hookstage.HookResult[hookstage.RawBidderResponsePayload]{Reject: false},
 			setup: func() {
-				mockMetricsEngine.EXPECT().RecordRequestStatus("pubmatic", "0").AnyTimes()
-				mockMetricsEngine.EXPECT().RecordWrapperCount("pubmatic", "1").AnyTimes()
-				mockMetricsEngine.EXPECT().RecordRequestTime("pubmatic", gomock.Any()).AnyTimes()
+				mockMetricsEngine.EXPECT().RecordRequestStatus("5890", "pubmatic", "0").AnyTimes()
+				mockMetricsEngine.EXPECT().RecordWrapperCount("5890", "pubmatic", "1").AnyTimes()
+				mockMetricsEngine.EXPECT().RecordRequestTime("5890", "pubmatic", gomock.Any()).AnyTimes()
 			},
 			unwrapRequest: func(w http.ResponseWriter, req *http.Request) {
 				w.Header().Add("unwrap-status", "0")
@@ -182,9 +218,9 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 			},
 			wantResult: hookstage.HookResult[hookstage.RawBidderResponsePayload]{Reject: false},
 			setup: func() {
-				mockMetricsEngine.EXPECT().RecordRequestStatus("pubmatic", "0").AnyTimes()
-				mockMetricsEngine.EXPECT().RecordWrapperCount("pubmatic", "1").AnyTimes()
-				mockMetricsEngine.EXPECT().RecordRequestTime("pubmatic", gomock.Any()).AnyTimes()
+				mockMetricsEngine.EXPECT().RecordRequestStatus("5890", "pubmatic", "0").AnyTimes()
+				mockMetricsEngine.EXPECT().RecordWrapperCount("5890", "pubmatic", "1").AnyTimes()
+				mockMetricsEngine.EXPECT().RecordRequestTime("5890", "pubmatic", gomock.Any()).AnyTimes()
 			},
 			unwrapRequest: func(w http.ResponseWriter, req *http.Request) {
 				w.Header().Add("unwrap-status", "0")
@@ -256,9 +292,9 @@ func TestHandleRawBidderResponseHook(t *testing.T) {
 				},
 			},
 			setup: func() {
-				mockMetricsEngine.EXPECT().RecordRequestStatus("pubmatic", "0").AnyTimes()
-				mockMetricsEngine.EXPECT().RecordWrapperCount("pubmatic", "0").AnyTimes()
-				mockMetricsEngine.EXPECT().RecordRequestTime("pubmatic", gomock.Any()).AnyTimes()
+				mockMetricsEngine.EXPECT().RecordRequestStatus("5890", "pubmatic", "0").AnyTimes()
+				mockMetricsEngine.EXPECT().RecordWrapperCount("5890", "pubmatic", "0").AnyTimes()
+				mockMetricsEngine.EXPECT().RecordRequestTime("5890", "pubmatic", gomock.Any()).AnyTimes()
 			},
 			unwrapRequest: func(w http.ResponseWriter, req *http.Request) {
 				w.Header().Add("unwrap-status", "0")

--- a/modules/pubmatic/vastunwrap/models/request.go
+++ b/modules/pubmatic/vastunwrap/models/request.go
@@ -1,6 +1,7 @@
 package models
 
 type RequestCtx struct {
-	UA                string
-	VastUnwrapEnabled bool
+	UA                     string
+	VastUnwrapEnabled      bool
+	VastUnwrapStatsEnabled bool
 }

--- a/modules/pubmatic/vastunwrap/module.go
+++ b/modules/pubmatic/vastunwrap/module.go
@@ -17,11 +17,12 @@ import (
 )
 
 type VastUnwrapModule struct {
-	Cfg               unWrapCfg.VastUnWrapCfg `mapstructure:"vastunwrap_cfg" json:"vastunwrap_cfg"`
-	TrafficPercentage int                     `mapstructure:"traffic_percentage" json:"traffic_percentage"`
-	Enabled           bool                    `mapstructure:"enabled" json:"enabled"`
-	MetricsEngine     metrics.MetricsEngine
-	unwrapRequest     func(w http.ResponseWriter, r *http.Request)
+	Cfg                   unWrapCfg.VastUnWrapCfg `mapstructure:"vastunwrap_cfg" json:"vastunwrap_cfg"`
+	TrafficPercentage     int                     `mapstructure:"traffic_percentage" json:"traffic_percentage"`
+	StatTrafficPercentage int                     `mapstructure:"stat_traffic_percentage" json:"stat_traffic_percentage"`
+	Enabled               bool                    `mapstructure:"enabled" json:"enabled"`
+	MetricsEngine         metrics.MetricsEngine
+	unwrapRequest         func(w http.ResponseWriter, r *http.Request)
 }
 
 func Builder(rawCfg json.RawMessage, deps moduledeps.ModuleDeps) (interface{}, error) {

--- a/modules/pubmatic/vastunwrap/module_test.go
+++ b/modules/pubmatic/vastunwrap/module_test.go
@@ -161,9 +161,9 @@ func TestVastUnwrapModuleHandleRawBidderResponseHook(t *testing.T) {
 				wantAdM: true,
 			},
 			setup: func() {
-				mockMetricsEngine.EXPECT().RecordRequestStatus("pubmatic", "0")
-				mockMetricsEngine.EXPECT().RecordWrapperCount("pubmatic", "1")
-				mockMetricsEngine.EXPECT().RecordRequestTime("pubmatic", gomock.Any())
+				mockMetricsEngine.EXPECT().RecordRequestStatus("5890", "pubmatic", "0")
+				mockMetricsEngine.EXPECT().RecordWrapperCount("5890", "pubmatic", "1")
+				mockMetricsEngine.EXPECT().RecordRequestTime("5890", "pubmatic", gomock.Any())
 			},
 			unwrapRequest: func(w http.ResponseWriter, req *http.Request) {
 				w.Header().Add("unwrap-status", "0")

--- a/modules/pubmatic/vastunwrap/stats/metrics.go
+++ b/modules/pubmatic/vastunwrap/stats/metrics.go
@@ -20,9 +20,9 @@ const (
 
 // MetricsEngine is a generic interface to record metrics into the desired backend
 type MetricsEngine interface {
-	RecordRequestStatus(bidder, status string)
-	RecordWrapperCount(bidder string, wrapper_count string)
-	RecordRequestTime(bidder string, readTime time.Duration)
+	RecordRequestStatus(accountId, bidder, status string)
+	RecordWrapperCount(accountId, bidder string, wrapper_count string)
+	RecordRequestTime(accountId, bidder string, readTime time.Duration)
 }
 
 // Metrics defines the datatype which will implement MetricsEngine
@@ -48,14 +48,14 @@ func NewMetricsEngine(cfg moduledeps.ModuleDeps) (*Metrics, error) {
 	metrics.requests = newCounter(cfg.MetricsCfg.Prometheus, metrics.Registry,
 		"vastunwrap_status",
 		"Count of vast unwrap requests labeled by status",
-		[]string{bidderLabel, statusLabel})
+		[]string{pubIdLabel, bidderLabel, statusLabel})
 	metrics.wrapperCount = newCounter(cfg.MetricsCfg.Prometheus, metrics.Registry,
 		"vastunwrap_wrapper_count",
 		"Count of vast unwrap levels labeled by bidder",
-		[]string{bidderLabel, wrapperCountLabel})
+		[]string{pubIdLabel, bidderLabel, wrapperCountLabel})
 	metrics.requestTime = newHistogramVec(cfg.MetricsCfg.Prometheus, metrics.Registry,
 		"vastunwrap_request_time",
-		"Time taken to serve the vast unwrap request in Milliseconds", []string{bidderLabel},
+		"Time taken to serve the vast unwrap request in Milliseconds", []string{pubIdLabel, bidderLabel},
 		[]float64{50, 100, 200, 300, 500})
 	return &metrics, nil
 }
@@ -86,24 +86,27 @@ func newHistogramVec(cfg config.PrometheusMetrics, registry *prometheus.Registry
 }
 
 // RecordRequest record counter with vast unwrap status
-func (m *Metrics) RecordRequestStatus(bidder, status string) {
+func (m *Metrics) RecordRequestStatus(accountId, bidder, status string) {
 	m.requests.With(prometheus.Labels{
+		pubIdLabel:  accountId,
 		bidderLabel: bidder,
 		statusLabel: status,
 	}).Inc()
 }
 
 // RecordWrapperCount record counter of wrapper levels
-func (m *Metrics) RecordWrapperCount(bidder, wrapper_count string) {
+func (m *Metrics) RecordWrapperCount(accountId, bidder, wrapper_count string) {
 	m.wrapperCount.With(prometheus.Labels{
+		pubIdLabel:        accountId,
 		bidderLabel:       bidder,
 		wrapperCountLabel: wrapper_count,
 	}).Inc()
 }
 
 // RecordRequestReadTime records time takent to complete vast unwrap
-func (m *Metrics) RecordRequestTime(bidder string, requestTime time.Duration) {
+func (m *Metrics) RecordRequestTime(accountId, bidder string, requestTime time.Duration) {
 	m.requestTime.With(prometheus.Labels{
+		pubIdLabel:  accountId,
 		bidderLabel: bidder,
 	}).Observe(float64(requestTime.Milliseconds()))
 }

--- a/modules/pubmatic/vastunwrap/stats/metrics_test.go
+++ b/modules/pubmatic/vastunwrap/stats/metrics_test.go
@@ -36,7 +36,7 @@ func createMetricsForTesting() *Metrics {
 func TestRecordRequestTime(t *testing.T) {
 	m := createMetricsForTesting()
 
-	m.RecordRequestTime("pubmatic", time.Millisecond*250)
+	m.RecordRequestTime("1234", "pubmatic", time.Millisecond*250)
 
 	result := getHistogramFromHistogramVec(m.requestTime, "bidder", "pubmatic")
 	assertHistogram(t, result, 1, 250)
@@ -44,9 +44,10 @@ func TestRecordRequestTime(t *testing.T) {
 func TestRecordRequestStatus(t *testing.T) {
 	m := createMetricsForTesting()
 
-	m.RecordRequestStatus("pubmatic", "0")
+	m.RecordRequestStatus("1234", "pubmatic", "0")
 
 	assertCounterVecValue(t, "Record_Request_Status", "Record_Request_Status_Success", m.requests, float64(1), prometheus.Labels{
+		"pub_id": "1234",
 		"bidder": "pubmatic",
 		"status": "0",
 	})
@@ -55,9 +56,10 @@ func TestRecordRequestStatus(t *testing.T) {
 func TestRecordWrapperCount(t *testing.T) {
 	m := createMetricsForTesting()
 
-	m.RecordWrapperCount("pubmatic", "1")
+	m.RecordWrapperCount("1234", "pubmatic", "1")
 
 	assertCounterVecValue(t, "Record_Wrapper_Count", "Record_Wrapper_Count", m.wrapperCount, float64(1), prometheus.Labels{
+		"pub_id":        "1234",
 		"bidder":        "pubmatic",
 		"wrapper_count": "1",
 	})

--- a/modules/pubmatic/vastunwrap/stats/mock/mock.go
+++ b/modules/pubmatic/vastunwrap/stats/mock/mock.go
@@ -34,37 +34,37 @@ func (m *MockMetricsEngine) EXPECT() *MockMetricsEngineMockRecorder {
 }
 
 // RecordRequestStatus mocks base method
-func (m *MockMetricsEngine) RecordRequestStatus(arg0, arg1 string) {
+func (m *MockMetricsEngine) RecordRequestStatus(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RecordRequestStatus", arg0, arg1)
+	m.ctrl.Call(m, "RecordRequestStatus", arg0, arg1, arg2)
 }
 
 // RecordRequestStatus indicates an expected call of RecordRequestStatus
-func (mr *MockMetricsEngineMockRecorder) RecordRequestStatus(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMetricsEngineMockRecorder) RecordRequestStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordRequestStatus", reflect.TypeOf((*MockMetricsEngine)(nil).RecordRequestStatus), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordRequestStatus", reflect.TypeOf((*MockMetricsEngine)(nil).RecordRequestStatus), arg0, arg1, arg2)
 }
 
 // RecordWrapperCount mocks base method
-func (m *MockMetricsEngine) RecordWrapperCount(arg0, arg1 string) {
+func (m *MockMetricsEngine) RecordWrapperCount(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RecordWrapperCount", arg0, arg1)
+	m.ctrl.Call(m, "RecordWrapperCount", arg0, arg1, arg2)
 }
 
 // RecordWrapperCount indicates an expected call of RecordRequestStatus
-func (mr *MockMetricsEngineMockRecorder) RecordWrapperCount(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMetricsEngineMockRecorder) RecordWrapperCount(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordWrapperCount", reflect.TypeOf((*MockMetricsEngine)(nil).RecordWrapperCount), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordWrapperCount", reflect.TypeOf((*MockMetricsEngine)(nil).RecordWrapperCount), arg0, arg1, arg2)
 }
 
 // RecordRequestTime mocks base method
-func (m *MockMetricsEngine) RecordRequestTime(arg0 string, arg1 time.Duration) {
+func (m *MockMetricsEngine) RecordRequestTime(arg0, arg1 string, arg2 time.Duration) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RecordRequestTime", arg0, arg1)
+	m.ctrl.Call(m, "RecordRequestTime", arg0, arg1, arg2)
 }
 
 // RecordRequestTime indicates an expected call of RecordRequestTime
-func (mr *MockMetricsEngineMockRecorder) RecordRequestTime(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMetricsEngineMockRecorder) RecordRequestTime(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordRequestTime", reflect.TypeOf((*MockMetricsEngine)(nil).RecordRequestTime), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordRequestTime", reflect.TypeOf((*MockMetricsEngine)(nil).RecordRequestTime), arg0, arg1, arg2)
 }

--- a/modules/pubmatic/vastunwrap/unwrap_service_test.go
+++ b/modules/pubmatic/vastunwrap/unwrap_service_test.go
@@ -21,6 +21,7 @@ func TestDoUnwrap(t *testing.T) {
 	mockMetricsEngine := mock_stats.NewMockMetricsEngine(ctrl)
 	type args struct {
 		module               VastUnwrapModule
+		statsEnabled         bool
 		bid                  *adapters.TypedBid
 		userAgent            string
 		unwrapDefaultTimeout int
@@ -83,8 +84,8 @@ func TestDoUnwrap(t *testing.T) {
 				url:       "testURL",
 			},
 			setup: func() {
-				mockMetricsEngine.EXPECT().RecordRequestStatus("pubmatic", "2")
-				mockMetricsEngine.EXPECT().RecordRequestTime("pubmatic", gomock.Any())
+				mockMetricsEngine.EXPECT().RecordRequestStatus("5890", "pubmatic", "2")
+				mockMetricsEngine.EXPECT().RecordRequestTime("5890", "pubmatic", gomock.Any())
 			},
 			unwrapRequest: func(w http.ResponseWriter, req *http.Request) {
 				w.Header().Add("unwrap-status", "2")
@@ -113,9 +114,9 @@ func TestDoUnwrap(t *testing.T) {
 				wantAdM:   true,
 			},
 			setup: func() {
-				mockMetricsEngine.EXPECT().RecordRequestStatus("pubmatic", "0")
-				mockMetricsEngine.EXPECT().RecordWrapperCount("pubmatic", "1")
-				mockMetricsEngine.EXPECT().RecordRequestTime("pubmatic", gomock.Any())
+				mockMetricsEngine.EXPECT().RecordRequestStatus("5890", "pubmatic", "0")
+				mockMetricsEngine.EXPECT().RecordWrapperCount("5890", "pubmatic", "1")
+				mockMetricsEngine.EXPECT().RecordRequestTime("5890", "pubmatic", gomock.Any())
 			},
 			unwrapRequest: func(w http.ResponseWriter, req *http.Request) {
 				w.Header().Add("unwrap-status", "0")
@@ -145,8 +146,8 @@ func TestDoUnwrap(t *testing.T) {
 				wantAdM:   false,
 			},
 			setup: func() {
-				mockMetricsEngine.EXPECT().RecordRequestStatus("pubmatic", "1")
-				mockMetricsEngine.EXPECT().RecordRequestTime("pubmatic", gomock.Any())
+				mockMetricsEngine.EXPECT().RecordRequestStatus("5890", "pubmatic", "1")
+				mockMetricsEngine.EXPECT().RecordRequestTime("5890", "pubmatic", gomock.Any())
 			},
 			unwrapRequest: func(w http.ResponseWriter, req *http.Request) {
 				w.Header().Add("unwrap-status", "1")
@@ -167,7 +168,7 @@ func TestDoUnwrap(t *testing.T) {
 				MetricsEngine: mockMetricsEngine,
 				unwrapRequest: tt.unwrapRequest,
 			}
-			m.doUnwrapandUpdateBid(tt.args.bid, tt.args.userAgent, tt.args.url, "5890", "pubmatic")
+			m.doUnwrapandUpdateBid(tt.args.statsEnabled, tt.args.bid, tt.args.userAgent, tt.args.url, "5890", "pubmatic")
 			if tt.args.bid.Bid.AdM != "" && tt.args.wantAdM {
 				assert.Equal(t, inlineXMLAdM, tt.args.bid.Bid.AdM, "AdM is not updated correctly after executing RawBidderResponse hook.")
 			}


### PR DESCRIPTION


# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
