### PR TITLE
UOE-9681: Trace marshal error fix

### DIFF
--- a/modules/pubmatic/openwrap/models/openwrap.go
+++ b/modules/pubmatic/openwrap/models/openwrap.go
@@ -93,8 +93,8 @@ type RequestCtx struct {
 	Sshb                   string //Sshb query param to identify that the request executed heder-bidding or not, sshb=1(executed HB(8001)), sshb=2(reverse proxy set from HB(8001->8000)), sshb=""(direct request(8000)).
 
 	DCName             string
-	CachePutMiss       int // to be used in case of CTV JSON endpoint/amp/inapp-ott-video endpoint
-	CurrencyConversion func(from string, to string, value float64) (float64, error)
+	CachePutMiss       int                                                          // to be used in case of CTV JSON endpoint/amp/inapp-ott-video endpoint
+	CurrencyConversion func(from string, to string, value float64) (float64, error) `json:"-"`
 	MatchedImpression  map[string]int
 }
 


### PR DESCRIPTION
Fixed marshling error when we send trace=verbose in request.
