### PR TITLE
OTT-1541: req.device.UA should get higher priority over UA from request-header while sending owlogger to wtracker-server

### DIFF
--- a/modules/pubmatic/openwrap/beforevalidationhook.go
+++ b/modules/pubmatic/openwrap/beforevalidationhook.go
@@ -79,6 +79,9 @@ func (m OpenWrap) handleBeforeValidationHook(
 	rCtx.Source, rCtx.Origin = getSourceAndOrigin(payload.BidRequest)
 	rCtx.PageURL = getPageURL(payload.BidRequest)
 	rCtx.Platform = getPlatformFromRequest(payload.BidRequest)
+	if userAgent := getUserAgent(payload.BidRequest); userAgent != "" {
+		rCtx.UA = userAgent
+	}
 	rCtx.Device.Platform = getDevicePlatform(rCtx, payload.BidRequest)
 	populateDeviceExt(payload.BidRequest, &rCtx.Device)
 

--- a/modules/pubmatic/openwrap/beforevalidationhook.go
+++ b/modules/pubmatic/openwrap/beforevalidationhook.go
@@ -79,9 +79,7 @@ func (m OpenWrap) handleBeforeValidationHook(
 	rCtx.Source, rCtx.Origin = getSourceAndOrigin(payload.BidRequest)
 	rCtx.PageURL = getPageURL(payload.BidRequest)
 	rCtx.Platform = getPlatformFromRequest(payload.BidRequest)
-	if userAgent := getUserAgent(payload.BidRequest); userAgent != "" {
-		rCtx.UA = userAgent
-	}
+	rCtx.UA = getUserAgent(payload.BidRequest, rCtx.UA)
 	rCtx.Device.Platform = getDevicePlatform(rCtx, payload.BidRequest)
 	populateDeviceExt(payload.BidRequest, &rCtx.Device)
 

--- a/modules/pubmatic/openwrap/beforevalidationhook_test.go
+++ b/modules/pubmatic/openwrap/beforevalidationhook_test.go
@@ -2842,51 +2842,6 @@ func TestUserAgent_handleBeforeValidationHook(t *testing.T) {
 	}
 }
 
-func TestGetUserAgentFromRequest(t *testing.T) {
-	tests := []struct {
-		name    string
-		request *openrtb2.BidRequest
-		wantUA  string
-	}{
-		{
-			name:    "bidrequest_nil",
-			request: nil,
-			wantUA:  "",
-		},
-		{
-			name: "device_nil",
-			request: &openrtb2.BidRequest{
-				Device: nil,
-			},
-			wantUA: "",
-		},
-		{
-			name: "ua_empty",
-			request: &openrtb2.BidRequest{
-				Device: &openrtb2.Device{
-					UA: "",
-				},
-			},
-			wantUA: "",
-		},
-		{
-			name: "valid_ua",
-			request: &openrtb2.BidRequest{
-				Device: &openrtb2.Device{
-					UA: "Mozilla/5.0(X11;Linuxx86_64)AppleWebKit/537.36(KHTML,likeGecko)Chrome/52.0.2743.82Safari/537.36",
-				},
-			},
-			wantUA: "Mozilla/5.0(X11;Linuxx86_64)AppleWebKit/537.36(KHTML,likeGecko)Chrome/52.0.2743.82Safari/537.36",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ua := getUserAgent(tt.request)
-			assert.Equal(t, tt.wantUA, ua, "mismatched UA")
-		})
-	}
-}
-
 func TestGetSlotName(t *testing.T) {
 	type args struct {
 		tagId  string

--- a/modules/pubmatic/openwrap/util.go
+++ b/modules/pubmatic/openwrap/util.go
@@ -283,8 +283,8 @@ func isCTV(userAgent string) bool {
 }
 
 // getUserAgent returns value of bidRequest.Device.UA if present else returns empty string
-func getUserAgent(bidRequest *openrtb2.BidRequest) string {
-	var userAgent string
+func getUserAgent(bidRequest *openrtb2.BidRequest, defaultUA string) string {
+	userAgent := defaultUA
 	if bidRequest != nil && bidRequest.Device != nil && len(bidRequest.Device.UA) > 0 {
 		userAgent = bidRequest.Device.UA
 	}

--- a/modules/pubmatic/openwrap/util.go
+++ b/modules/pubmatic/openwrap/util.go
@@ -51,10 +51,6 @@ func init() {
 // getDevicePlatform determines the device from which request has been generated
 func getDevicePlatform(rCtx models.RequestCtx, bidRequest *openrtb2.BidRequest) models.DevicePlatform {
 	userAgentString := rCtx.UA
-	if bidRequest != nil && bidRequest.Device != nil && len(bidRequest.Device.UA) != 0 {
-		userAgentString = bidRequest.Device.UA
-		rCtx.UA = userAgentString
-	}
 
 	switch rCtx.Platform {
 	case models.PLATFORM_AMP:
@@ -284,6 +280,15 @@ func getPubmaticErrorCode(standardNBR int) int {
 
 func isCTV(userAgent string) bool {
 	return ctvRegex.Match([]byte(userAgent))
+}
+
+// getUserAgent returns value of bidRequest.Device.UA if present else returns empty string
+func getUserAgent(bidRequest *openrtb2.BidRequest) string {
+	var userAgent string
+	if bidRequest != nil && bidRequest.Device != nil && len(bidRequest.Device.UA) > 0 {
+		userAgent = bidRequest.Device.UA
+	}
+	return userAgent
 }
 
 func getPlatformFromRequest(request *openrtb2.BidRequest) string {

--- a/modules/pubmatic/openwrap/util_test.go
+++ b/modules/pubmatic/openwrap/util_test.go
@@ -263,7 +263,7 @@ func TestGetDevicePlatform(t *testing.T) {
 			name: "Test_platform_in-app_with_device.ua_for_ios",
 			args: args{
 				rCtx: models.RequestCtx{
-					UA:       "",
+					UA:       "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1",
 					Platform: "in-app",
 				},
 				bidRequest: getORTBRequest("", "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1", 0, false, true),
@@ -307,7 +307,7 @@ func TestGetDevicePlatform(t *testing.T) {
 			name: "Test_platform_display_with_device.ua_for_mobile",
 			args: args{
 				rCtx: models.RequestCtx{
-					UA:       "",
+					UA:       "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1",
 					Platform: "display",
 				},
 				bidRequest: getORTBRequest("", "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1", 0, true, false),
@@ -387,7 +387,7 @@ func TestGetDevicePlatform(t *testing.T) {
 			name: "Test_platform_video_with_site_entry_and_mobile_UA",
 			args: args{
 				rCtx: models.RequestCtx{
-					UA:       "",
+					UA:       "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1",
 					Platform: "video",
 				},
 				bidRequest: getORTBRequest("", "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1", 0, true, false),
@@ -398,7 +398,7 @@ func TestGetDevicePlatform(t *testing.T) {
 			name: "Test_platform_video_with_app_entry_and_iOS_mobile_UA",
 			args: args{
 				rCtx: models.RequestCtx{
-					UA:       "",
+					UA:       "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1",
 					Platform: "video",
 				},
 				bidRequest: getORTBRequest("", "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1", 0, false, true),
@@ -409,7 +409,7 @@ func TestGetDevicePlatform(t *testing.T) {
 			name: "Test_platform_video_with_app_entry_and_android_mobile_UA",
 			args: args{
 				rCtx: models.RequestCtx{
-					UA:       "",
+					UA:       "Mozilla/5.0 (Linux; Android 7.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/1.0 Chrome/59.0.3029.83 Mobile Safari/537.36",
 					Platform: "video",
 				},
 
@@ -443,7 +443,7 @@ func TestGetDevicePlatform(t *testing.T) {
 			name: "Test_platform_video_with_CTV_and_device_type",
 			args: args{
 				rCtx: models.RequestCtx{
-					UA:       "",
+					UA:       "Mozilla/5.0 (SMART-TV; Linux; Tizen 4.0) AppleWebKit/538.1 (KHTML, like Gecko) Version/4.0 TV Safari/538.1",
 					Platform: "video",
 					PubIDStr: "5890",
 				},
@@ -455,7 +455,7 @@ func TestGetDevicePlatform(t *testing.T) {
 			name: "Test_platform_video_with_CTV_and_no_device_type",
 			args: args{
 				rCtx: models.RequestCtx{
-					UA:       "",
+					UA:       "AppleCoreMedia/1.0.0.20L498 (Apple TV; U; CPU OS 16_4_1 like Mac OS X; en_us)",
 					Platform: "video",
 				},
 				bidRequest: getORTBRequest("", "AppleCoreMedia/1.0.0.20L498 (Apple TV; U; CPU OS 16_4_1 like Mac OS X; en_us)", 0, true, false),
@@ -466,7 +466,7 @@ func TestGetDevicePlatform(t *testing.T) {
 			name: "Test_platform_video_for_non_CTV_User_agent_with_device_type_7",
 			args: args{
 				rCtx: models.RequestCtx{
-					UA:       "",
+					UA:       "AppleCoreMedia/1.0.0.20L498 (iphone ; U; CPU OS 16_4_1 like Mac OS X; en_us)",
 					Platform: "video",
 					PubIDStr: "5890",
 				},

--- a/modules/pubmatic/openwrap/util_test.go
+++ b/modules/pubmatic/openwrap/util_test.go
@@ -574,6 +574,68 @@ func TestIsMobile(t *testing.T) {
 	}
 }
 
+func Test_getUserAgent(t *testing.T) {
+	type args struct {
+		request   *openrtb2.BidRequest
+		defaultUA string
+	}
+	tests := []struct {
+		name   string
+		args   args
+		wantUA string
+	}{
+		{
+			name: "request_is_nil",
+			args: args{
+				request:   nil,
+				defaultUA: "default-ua",
+			},
+
+			wantUA: "default-ua",
+		},
+		{
+			name: "req.device_is_nil",
+			args: args{
+				request: &openrtb2.BidRequest{
+					Device: nil,
+				},
+				defaultUA: "default-ua",
+			},
+			wantUA: "default-ua",
+		},
+		{
+			name: "req.device.ua_empty",
+			args: args{
+				request: &openrtb2.BidRequest{
+					Device: &openrtb2.Device{
+						UA: "",
+					},
+				},
+				defaultUA: "default-ua",
+			},
+			wantUA: "default-ua",
+		},
+		{
+			name: "req.device.ua_valid",
+			args: args{
+				request: &openrtb2.BidRequest{
+					Device: &openrtb2.Device{
+						UA: "Mozilla/5.0(X11;Linuxx86_64)AppleWebKit/537.36(KHTML,likeGecko)Chrome/52.0.2743.82Safari/537.36",
+					},
+				},
+				defaultUA: "default-ua",
+			},
+			wantUA: "Mozilla/5.0(X11;Linuxx86_64)AppleWebKit/537.36(KHTML,likeGecko)Chrome/52.0.2743.82Safari/537.36",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ua := getUserAgent(tt.args.request, tt.args.defaultUA)
+			assert.Equal(t, tt.wantUA, ua, "mismatched UA")
+		})
+	}
+}
+
 func TestIsIos(t *testing.T) {
 	type args struct {
 		os              string


### PR DESCRIPTION
- When we enable the hook and send the traffic through the module then in-correct UA is being send to the wtracker server.
- It is expected that high priority should be given to the "device.UA" over request-header, but in case of modular flow we only considers the request-header.
- Root-cause :
 rCtx is **pass-by-value** to function getDevicePlatform and getDevicePlatform attempts to modify it inside the function but reciever never get the modified value.