### PR TITLE
UOE-10050: Fetch vendorId for VastBidder from db table

### DIFF
--- a/modules/pubmatic/openwrap/database/mysql/partner_config.go
+++ b/modules/pubmatic/openwrap/database/mysql/partner_config.go
@@ -65,9 +65,7 @@ func (db *mySqlDB) getActivePartnerConfigurations(versionID int) (map[int]map[st
 			partnerConfigMap[partnerID][models.PREBID_PARTNER_NAME] = prebidPartnerName
 			partnerConfigMap[partnerID][models.BidderCode] = bidderCode
 			partnerConfigMap[partnerID][models.IsAlias] = strconv.Itoa(isAlias)
-			if prebidPartnerName != models.BidderVASTBidder {
-				partnerConfigMap[partnerID][models.VENDORID] = strconv.Itoa(vendorID)
-			}
+			partnerConfigMap[partnerID][models.VENDORID] = strconv.Itoa(vendorID)
 		}
 	}
 

--- a/modules/pubmatic/openwrap/database/mysql/partner_config_test.go
+++ b/modules/pubmatic/openwrap/database/mysql/partner_config_test.go
@@ -227,7 +227,7 @@ func Test_mySqlDB_GetActivePartnerConfigurations(t *testing.T) {
 					"serverSideEnabled": "1",
 					"isAlias":           "0",
 					"partnerId":         "234",
-					"vendorId":          "999",
+					"vendorId":          "546",
 				},
 				101: {
 					"bidderCode":        "pubmatic",
@@ -266,8 +266,8 @@ func Test_mySqlDB_GetActivePartnerConfigurations(t *testing.T) {
 					AddRow("101", "pubmatic", "pubmatic", 0, 3, 0, 76, "kgp", "_AU_@_W_x_H_").
 					AddRow("101", "pubmatic", "pubmatic", 0, 3, 0, 76, "timeout", "200").
 					AddRow("101", "pubmatic", "pubmatic", 0, 3, 0, 76, "serverSideEnabled", "1").
-					AddRow("234", "vastbidder", "test-vastbidder", 0, 3, 0, -1, "serverSideEnabled", "1").
-					AddRow("234", "vastbidder", "test-vastbidder", 0, 3, 0, -1, "vendorId", "999")
+					AddRow("234", "vastbidder", "test-vastbidder", 0, 3, 0, 546, "vendorId", "999").
+					AddRow("234", "vastbidder", "test-vastbidder", 0, 3, 0, 546, "serverSideEnabled", "1")
 				mock.ExpectQuery(regexp.QuoteMeta("^SELECT (.+) FROM wrapper_config_map (.+)")).WillReturnRows(rowsPartnerConfig)
 				return db
 			},


### PR DESCRIPTION
# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
