### PR TITLE
OTT-1654: Impression are getting formed for inline hb when nothing is in range

### DIFF
--- a/modules/pubmatic/openwrap/adpod/adpod.go
+++ b/modules/pubmatic/openwrap/adpod/adpod.go
@@ -82,7 +82,7 @@ func resolveAdpodConfigs(impVideo *openrtb2.Video, requestExtConfigs *models.Ext
 
 }
 
-func Validate(config *models.AdPod, video *openrtb2.Video) error {
+func Validate(config *models.AdPod) error {
 	if config == nil {
 		return nil
 	}

--- a/modules/pubmatic/openwrap/adpod/adpod.go
+++ b/modules/pubmatic/openwrap/adpod/adpod.go
@@ -82,7 +82,7 @@ func resolveAdpodConfigs(impVideo *openrtb2.Video, requestExtConfigs *models.Ext
 
 }
 
-func Validate(config *models.AdPod) error {
+func Validate(config *models.AdPod, video *openrtb2.Video) error {
 	if config == nil {
 		return nil
 	}
@@ -117,6 +117,20 @@ func Validate(config *models.AdPod) error {
 
 	if config.MinDuration > config.MaxDuration {
 		return errors.New("adpod.adminduration must be less than adpod.admaxduration")
+	}
+
+	if len(config.VideoAdDuration) > 0 {
+		validDurations := false
+		for _, videoDuration := range config.VideoAdDuration {
+			if videoDuration >= config.MinDuration && videoDuration <= config.MaxDuration {
+				validDurations = true
+				break
+			}
+		}
+
+		if !validDurations {
+			return errors.New("videoAdDuration values should be between adpod.adminduration and dpod.adminduration")
+		}
 	}
 
 	return nil

--- a/modules/pubmatic/openwrap/beforevalidationhook.go
+++ b/modules/pubmatic/openwrap/beforevalidationhook.go
@@ -352,7 +352,7 @@ func (m OpenWrap) handleBeforeValidationHook(
 				adpodConfig.VideoAdDurationMatching = openrtb_ext.OWRoundupVideoAdDurationMatching
 			}
 
-			if err := adpod.Validate(adpodConfig); err != nil {
+			if err := adpod.Validate(adpodConfig, imp.Video); err != nil {
 				result.NbrCode = nbr.InvalidAdpodConfig
 				result.Errors = append(result.Errors, "invalid adpod configurations for "+imp.ID+" reason: "+err.Error())
 				return result, nil

--- a/modules/pubmatic/openwrap/beforevalidationhook.go
+++ b/modules/pubmatic/openwrap/beforevalidationhook.go
@@ -352,7 +352,7 @@ func (m OpenWrap) handleBeforeValidationHook(
 				adpodConfig.VideoAdDurationMatching = openrtb_ext.OWRoundupVideoAdDurationMatching
 			}
 
-			if err := adpod.Validate(adpodConfig, imp.Video); err != nil {
+			if err := adpod.Validate(adpodConfig); err != nil {
 				result.NbrCode = nbr.InvalidAdpodConfig
 				result.Errors = append(result.Errors, "invalid adpod configurations for "+imp.ID+" reason: "+err.Error())
 				return result, nil

--- a/modules/pubmatic/openwrap/beforevalidationhook_test.go
+++ b/modules/pubmatic/openwrap/beforevalidationhook_test.go
@@ -3160,7 +3160,7 @@ func TestImpBidCtx_handleBeforeValidationHook(t *testing.T) {
 					ImpBidCtx: map[string]models.ImpCtx{
 						"123": {
 							IncomingSlots: []string{
-								"640x480v",
+								"640x480",
 							},
 							SlotName:   "adunit",
 							AdUnitName: "adunit",
@@ -3211,7 +3211,7 @@ func TestImpBidCtx_handleBeforeValidationHook(t *testing.T) {
 					ImpBidCtx: map[string]models.ImpCtx{
 						"123": {
 							IncomingSlots: []string{
-								"640x480v",
+								"640x480",
 							},
 							SlotName:   "adunit",
 							AdUnitName: "adunit",
@@ -3264,7 +3264,7 @@ func TestImpBidCtx_handleBeforeValidationHook(t *testing.T) {
 					ImpBidCtx: map[string]models.ImpCtx{
 						"123": {
 							IncomingSlots: []string{
-								"640x480v",
+								"640x480",
 							},
 							SlotName:   "adunit",
 							AdUnitName: "adunit",

--- a/modules/pubmatic/openwrap/logger_test.go
+++ b/modules/pubmatic/openwrap/logger_test.go
@@ -88,7 +88,7 @@ func Test_getIncomingSlots(t *testing.T) {
 					},
 				},
 			},
-			want: []string{"300x250v"},
+			want: []string{"300x250"},
 		},
 		{
 			name: "all_slots",
@@ -114,7 +114,7 @@ func Test_getIncomingSlots(t *testing.T) {
 					},
 				},
 			},
-			want: []string{"300x250", "400x300", "300x250v"},
+			want: []string{"300x250", "400x300"},
 		},
 		{
 			name: "duplicate_slot",


### PR DESCRIPTION
# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
