### PR TITLE
OTT-1722: Fix panic when VAST element is missing in video creative for CTV adpod request

### DIFF
--- a/endpoints/openrtb2/ctv_auction.go
+++ b/endpoints/openrtb2/ctv_auction.go
@@ -943,13 +943,13 @@ func (deps *ctvEndpointDeps) getAdPodBid(adpod *types.AdPodBid) *types.Bid {
 	bid.Price = adpod.Price
 	bid.ADomain = adpod.ADomain[:]
 	bid.Cat = adpod.Cat[:]
-	bid.AdM = *getAdPodBidCreative(deps.request.Imp[deps.impIndices[adpod.OriginalImpID]].Video, adpod, deps.cfg.GenerateBidID)
+	bid.AdM = *getAdPodBidCreative(adpod, deps.cfg.GenerateBidID)
 	bid.Ext = getAdPodBidExtension(adpod)
 	return &bid
 }
 
 // getAdPodBidCreative get commulative adpod bid details
-func getAdPodBidCreative(video *openrtb2.Video, adpod *types.AdPodBid, generatedBidID bool) *string {
+func getAdPodBidCreative(adpod *types.AdPodBid, generatedBidID bool) *string {
 	doc := etree.NewDocument()
 	vast := doc.CreateElement(constant.VASTElement)
 	sequenceNumber := 1
@@ -981,6 +981,10 @@ func getAdPodBidCreative(video *openrtb2.Video, adpod *types.AdPodBid, generated
 			}
 
 			vastTag := adDoc.SelectElement(constant.VASTElement)
+			if vastTag == nil {
+				util.Logf("error:[vast_element_missing_in_adm] seat:[%s] adm:[%s]", bid.Seat, bid.AdM)
+				continue
+			}
 
 			//Get Actual VAST Version
 			bidVASTVersion, _ := strconv.ParseFloat(vastTag.SelectAttrValue(constant.VASTVersionAttribute, constant.VASTDefaultVersionStr), 64)

--- a/endpoints/openrtb2/ctv_auction_test.go
+++ b/endpoints/openrtb2/ctv_auction_test.go
@@ -850,7 +850,7 @@ func TestGetAdPodBidCreative(t *testing.T) {
 			args: args{
 				adpod: &types.AdPodBid{
 					Bids: []*types.Bid{
-						&types.Bid{
+						{
 							Bid: &openrtb2.Bid{
 								AdM: "<xml>any_creative_without_vast</xml>",
 							},
@@ -866,7 +866,7 @@ func TestGetAdPodBidCreative(t *testing.T) {
 			args: args{
 				adpod: &types.AdPodBid{
 					Bids: []*types.Bid{
-						&types.Bid{
+						{
 							Bid: &openrtb2.Bid{
 								AdM: "<VAST><Ad>url_creative</Ad></VAST>",
 							},

--- a/endpoints/openrtb2/ctv_auction_test.go
+++ b/endpoints/openrtb2/ctv_auction_test.go
@@ -834,3 +834,54 @@ func TestRecordAdPodRejectedBids(t *testing.T) {
 		me.AssertNumberOfCalls(t, "RecordRejectedBids", test.want.expectedCalls)
 	}
 }
+
+func TestGetAdPodBidCreative(t *testing.T) {
+	type args struct {
+		adpod          *types.AdPodBid
+		generatedBidID bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "VAST_element_missing_in_adm",
+			args: args{
+				adpod: &types.AdPodBid{
+					Bids: []*types.Bid{
+						&types.Bid{
+							Bid: &openrtb2.Bid{
+								AdM: "<xml>any_creative_without_vast</xml>",
+							},
+						},
+					},
+				},
+				generatedBidID: false,
+			},
+			want: "<VAST version=\"2.0\"/>",
+		},
+		{
+			name: "VAST_element_present_in_adm",
+			args: args{
+				adpod: &types.AdPodBid{
+					Bids: []*types.Bid{
+						&types.Bid{
+							Bid: &openrtb2.Bid{
+								AdM: "<VAST><Ad>url_creative</Ad></VAST>",
+							},
+						},
+					},
+				},
+				generatedBidID: false,
+			},
+			want: "<VAST version=\"2.0\"><Ad sequence=\"1\"><![CDATA[url_creative]]></Ad></VAST>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getAdPodBidCreative(tt.args.adpod, tt.args.generatedBidID)
+			assert.Equalf(t, tt.want, *got, "found incorrect creative")
+		})
+	}
+}


### PR DESCRIPTION
Refer - https://inside.pubmatic.com:9443/jira/browse/OTT-1722 for more details