### PR TITLE
OTT-1738 :: provide exclusion config to adpod through request ext

### DIFF
--- a/endpoints/openrtb2/ctv/adpod/dynamic_adpod.go
+++ b/endpoints/openrtb2/ctv/adpod/dynamic_adpod.go
@@ -43,6 +43,8 @@ func NewDynamicAdpod(pubId string, imp openrtb2.Imp, adpodExt openrtb_ext.ExtVid
 	minPodDuration := imp.Video.MinDuration
 	maxPodDuration := imp.Video.MaxDuration
 
+	exclusion := getExclusionConfigs(imp.Video.PodID, reqAdpodExt)
+
 	if adpodExt.AdPod == nil {
 		adpodExt = openrtb_ext.ExtVideoAdPod{
 			Offset: ptrutil.ToPtr(0),
@@ -55,6 +57,15 @@ func NewDynamicAdpod(pubId string, imp openrtb2.Imp, adpodExt openrtb_ext.ExtVid
 				IABCategoryExclusionPercent: ptrutil.ToPtr(100),
 			},
 		}
+
+		if exclusion.AdvertiserDomainExclusion {
+			adpodExt.AdPod.AdvertiserExclusionPercent = ptrutil.ToPtr(0)
+		}
+
+		if exclusion.IABCategoryExclusion {
+			adpodExt.AdPod.IABCategoryExclusionPercent = ptrutil.ToPtr(0)
+		}
+
 		maxPodDuration = imp.Video.PodDur
 	}
 
@@ -64,6 +75,7 @@ func NewDynamicAdpod(pubId string, imp openrtb2.Imp, adpodExt openrtb_ext.ExtVid
 			Type:          Dynamic,
 			ReqAdpodExt:   reqAdpodExt,
 			MetricsEngine: metricsEngine,
+			Exclusion:     exclusion,
 		},
 		Imp:            imp,
 		VideoExt:       &adpodExt,

--- a/endpoints/openrtb2/ctv/adpod/structured_adpod.go
+++ b/endpoints/openrtb2/ctv/adpod/structured_adpod.go
@@ -160,6 +160,10 @@ func (sa *structuredAdpod) addDomains(domains []string) {
 }
 
 func (sa *structuredAdpod) isCategoryAlreadySelected(bid *types.Bid) bool {
+	if !sa.Exclusion.IABCategoryExclusion {
+		return false
+	}
+
 	if bid == nil || bid.Cat == nil {
 		return false
 	}
@@ -178,6 +182,10 @@ func (sa *structuredAdpod) isCategoryAlreadySelected(bid *types.Bid) bool {
 }
 
 func (sa *structuredAdpod) isDomainAlreadySelected(bid *types.Bid) bool {
+	if !sa.Exclusion.AdvertiserDomainExclusion {
+		return false
+	}
+
 	if bid == nil || bid.ADomain == nil {
 		return false
 	}

--- a/endpoints/openrtb2/ctv/adpod/structured_adpod.go
+++ b/endpoints/openrtb2/ctv/adpod/structured_adpod.go
@@ -24,13 +24,14 @@ type Slot struct {
 	TotalBids int
 }
 
-func NewStructuredAdpod(pubId string, metricsEngine metrics.MetricsEngine, reqAdpodExt *openrtb_ext.ExtRequestAdPod) *structuredAdpod {
+func NewStructuredAdpod(podId string, pubId string, metricsEngine metrics.MetricsEngine, reqAdpodExt *openrtb_ext.ExtRequestAdPod) *structuredAdpod {
 	adpod := structuredAdpod{
 		AdpodCtx: AdpodCtx{
 			PubId:         pubId,
 			Type:          Structured,
 			ReqAdpodExt:   reqAdpodExt,
 			MetricsEngine: metricsEngine,
+			Exclusion:     getExclusionConfigs(podId, reqAdpodExt),
 		},
 		ImpBidMap:  make(map[string][]*types.Bid),
 		WinningBid: make(map[string]types.Bid),

--- a/endpoints/openrtb2/ctv/adpod/structured_adpod_test.go
+++ b/endpoints/openrtb2/ctv/adpod/structured_adpod_test.go
@@ -846,7 +846,69 @@ func TestStructuredAdpodPerformAuctionAndExclusion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "price_based_auction_with_one_slot_no_bid",
+			fields: fields{
+				AdpodCtx: AdpodCtx{
+					Type: Structured,
+					Exclusion: Exclusion{
+						IABCategoryExclusion:      true,
+						AdvertiserDomainExclusion: true,
+					},
+				},
+				ImpBidMap: map[string][]*types.Bid{
+					"imp1": {
+						{
+							Bid: &openrtb2.Bid{
+								Price: 6,
+								Cat:   []string{"IAB-1"},
+							},
+							DealTierSatisfied: false,
+							Seat:              "pubmatic",
+						},
+						{
+							Bid: &openrtb2.Bid{
+								Price: 4,
+								Cat:   []string{"IAB-1"},
+							},
+							DealTierSatisfied: false,
+							Seat:              "appnexux",
+						},
+					},
+					"imp2": {
+						{
+							Bid: &openrtb2.Bid{
+								Price: 4,
+								Cat:   []string{"IAB-1"},
+							},
+							DealTierSatisfied: false,
+							Seat:              "index",
+						},
+						{
+							Bid: &openrtb2.Bid{
+								Price: 2,
+								Cat:   []string{"IAB-1"},
+							},
+							DealTierSatisfied: false,
+							Seat:              "pubmatic",
+						},
+					},
+				},
+				WinningBid: make(map[string]types.Bid),
+			},
+			wantWinningBid: map[string]types.Bid{
+				"imp1": {
+					Bid: &openrtb2.Bid{
+						Price: 6,
+						Cat:   []string{"IAB-1"},
+					},
+					DealTierSatisfied: false,
+					Seat:              "pubmatic",
+				},
+			},
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sa := &structuredAdpod{

--- a/endpoints/openrtb2/ctv/adpod/util.go
+++ b/endpoints/openrtb2/ctv/adpod/util.go
@@ -83,3 +83,29 @@ func createMapFromSlice(slice []string) map[string]bool {
 	}
 	return resultMap
 }
+
+func getExclusionConfigs(podId string, adpodExt *openrtb_ext.ExtRequestAdPod) Exclusion {
+	var exclusion Exclusion
+
+	if adpodExt != nil && adpodExt.Exclusion != nil {
+		var iabCategory, advertiserDomain bool
+		for i := range adpodExt.Exclusion.IABCategory {
+			if adpodExt.Exclusion.IABCategory[i] == podId {
+				iabCategory = true
+				break
+			}
+		}
+
+		for i := range adpodExt.Exclusion.AdvertiserDomain {
+			if adpodExt.Exclusion.AdvertiserDomain[i] == podId {
+				advertiserDomain = true
+				break
+			}
+		}
+
+		exclusion.IABCategoryExclusion = iabCategory
+		exclusion.AdvertiserDomainExclusion = advertiserDomain
+	}
+
+	return exclusion
+}

--- a/endpoints/openrtb2/ctv/adpod/util_test.go
+++ b/endpoints/openrtb2/ctv/adpod/util_test.go
@@ -83,3 +83,76 @@ func TestConvertToV25VideoRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestGetExclusionConfigs(t *testing.T) {
+	tests := []struct {
+		name     string
+		podId    string
+		adpodExt *openrtb_ext.ExtRequestAdPod
+		expected Exclusion
+	}{
+		{
+			name:     "Nil_adpodExt",
+			podId:    "testPodId",
+			adpodExt: nil,
+			expected: Exclusion{},
+		},
+		{
+			name:  "Nil_Exclusion",
+			podId: "testPodId",
+			adpodExt: &openrtb_ext.ExtRequestAdPod{
+				Exclusion: nil,
+			},
+			expected: Exclusion{},
+		},
+		{
+			name:  "IABCategory_exclusion_present",
+			podId: "testPodId",
+			adpodExt: &openrtb_ext.ExtRequestAdPod{
+				Exclusion: &openrtb_ext.AdpodExclusion{
+					IABCategory:      []string{"testPodId"},
+					AdvertiserDomain: []string{"otherPodId"},
+				},
+			},
+			expected: Exclusion{
+				IABCategoryExclusion:      true,
+				AdvertiserDomainExclusion: false,
+			},
+		},
+		{
+			name:  "AdvertiserDomain_exclusion_present",
+			podId: "testPodId",
+			adpodExt: &openrtb_ext.ExtRequestAdPod{
+				Exclusion: &openrtb_ext.AdpodExclusion{
+					IABCategory:      []string{"otherPodId"},
+					AdvertiserDomain: []string{"testPodId"},
+				},
+			},
+			expected: Exclusion{
+				IABCategoryExclusion:      false,
+				AdvertiserDomainExclusion: true,
+			},
+		},
+		{
+			name:  "No_exclusion_config_provided",
+			podId: "testPodId",
+			adpodExt: &openrtb_ext.ExtRequestAdPod{
+				Exclusion: &openrtb_ext.AdpodExclusion{
+					IABCategory:      []string{"otherPodId"},
+					AdvertiserDomain: []string{"anotherPodId"},
+				},
+			},
+			expected: Exclusion{
+				IABCategoryExclusion:      false,
+				AdvertiserDomainExclusion: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getExclusionConfigs(tt.podId, tt.adpodExt)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/endpoints/openrtb2/ctv_auction.go
+++ b/endpoints/openrtb2/ctv_auction.go
@@ -351,7 +351,7 @@ func (deps *ctvEndpointDeps) createStructuredAdpodCtx(imp openrtb2.Imp) {
 
 	podContext, ok := deps.podCtx[imp.Video.PodID]
 	if !ok {
-		podContext = adpod.NewStructuredAdpod(deps.labels.PubID, deps.metricsEngine, deps.reqExt)
+		podContext = adpod.NewStructuredAdpod(imp.Video.PodID, deps.labels.PubID, deps.metricsEngine, deps.reqExt)
 	}
 
 	podContext.AddImpressions(imp)

--- a/openrtb_ext/openwrap.go
+++ b/openrtb_ext/openwrap.go
@@ -79,6 +79,13 @@ type ExtRequestAdPod struct {
 	AdvertiserExclusionWindow           *int                            `json:"excladvwindow,omitempty"`           //Duration in minute between pods where exclusive advertiser rule needs to be applied
 	VideoAdDuration                     []int                           `json:"videoadduration,omitempty"`         //Range of ad durations allowed in the response
 	VideoAdDurationMatching             OWVideoAdDurationMatchingPolicy `json:"videoaddurationmatching,omitempty"` //Flag indicating exact ad duration requirement. (default)empty/exact/round.
+	Exclusion                           *AdpodExclusion                 `json:"exclusion,omitempty"`               //Exclusion parameters
+}
+
+// AdpodExclusion holds AdPod specific exclusion parameters
+type AdpodExclusion struct {
+	IABCategory      []string `json:"iabcategory,omitempty"`
+	AdvertiserDomain []string `json:"advertiserdomain,omitempty"`
 }
 
 // VideoAdPod holds Video AdPod specific extension parameters at impression level


### PR DESCRIPTION
Sample exclusion config:
```
{
  "ext": {
    "adpod": {
      "exclusion": {
        "iabcategory": [
          "pod1",
          "pod2"
        ],
        "advertiserdomain": [
          "pod1"
        ]
      }
    }
  }
} 
```