### PR TITLE
OTT-1982: Honor IFA over session_id if when ifa_type is absent

### DIFF
--- a/modules/pubmatic/openwrap/device.go
+++ b/modules/pubmatic/openwrap/device.go
@@ -54,7 +54,7 @@ func updateDeviceIFADetails(dvc *models.DeviceCtx) {
 		} else {
 			deviceExt.DeleteIFAType()
 		}
-	} else if extSessionID != "" {
+	} else if extSessionID != "" && dvc.DeviceIFA == "" {
 		dvc.DeviceIFA = extSessionID
 		dvc.IFATypeID = ptrutil.ToPtr(models.DeviceIfaTypeIdSessionId)
 		deviceExt.SetIFAType(models.DeviceIFATypeSESSIONID)

--- a/modules/pubmatic/openwrap/device_test.go
+++ b/modules/pubmatic/openwrap/device_test.go
@@ -391,17 +391,60 @@ func TestUpdateDeviceIFADetails(t *testing.T) {
 				},
 			},
 			want: &models.DeviceCtx{
+				DeviceIFA: `existing_ifa_id`,
+				Ext: func() *models.ExtDevice {
+					deviceExt := &models.ExtDevice{}
+					deviceExt.SetSessionID(`sample_session_id`)
+					return deviceExt
+				}(),
+			},
+		},
+		{
+			name: `ifa_type_missing_ifa_empty_session_id_present`,
+			args: args{
+				dvc: &models.DeviceCtx{
+					DeviceIFA: "",
+					Ext: func() *models.ExtDevice {
+						deviceExt := &models.ExtDevice{}
+						deviceExt.SetSessionID(`sample_session_id`)
+						return deviceExt
+					}(),
+				},
+			},
+			want: &models.DeviceCtx{
 				IFATypeID: ptrutil.ToPtr(9),
 				DeviceIFA: `sample_session_id`,
 				Ext: func() *models.ExtDevice {
 					deviceExt := &models.ExtDevice{}
 					deviceExt.SetIFAType(models.DeviceIFATypeSESSIONID)
 					deviceExt.SetSessionID(`sample_session_id`)
-
 					return deviceExt
 				}(),
 			},
 		},
+		{
+			name: `ifa_type_missing_ifa_not_present_session_id_present`,
+			args: args{
+				dvc: &models.DeviceCtx{
+					Ext: func() *models.ExtDevice {
+						deviceExt := &models.ExtDevice{}
+						deviceExt.SetSessionID(`sample_session_id`)
+						return deviceExt
+					}(),
+				},
+			},
+			want: &models.DeviceCtx{
+				IFATypeID: ptrutil.ToPtr(9),
+				DeviceIFA: `sample_session_id`,
+				Ext: func() *models.ExtDevice {
+					deviceExt := &models.ExtDevice{}
+					deviceExt.SetIFAType(models.DeviceIFATypeSESSIONID)
+					deviceExt.SetSessionID(`sample_session_id`)
+					return deviceExt
+				}(),
+			},
+		},
+
 		// TODO: Add test cases.
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
