### PR TITLE
UOE-11360: Use sessionduration and impdepth from signal only, ignore if present in request user extension

### DIFF
--- a/modules/pubmatic/openwrap/applovinmax.go
+++ b/modules/pubmatic/openwrap/applovinmax.go
@@ -188,28 +188,13 @@ func updateUser(signalUser *openrtb2.User, maxRequest *openrtb2.BidRequest) {
 
 	maxRequest.User.Data = signalUser.Data
 
-	//Pass user.ext.sessionduration and user.ext.impdepth to ow partners in case of ALMAX integration
-	keys := []string{"sessionduration", "impdepth"}
-
-	for _, key := range keys {
-		if field, dataType, _, err := jsonparser.Get(signalUser.Ext, key); err == nil {
-			if field != nil {
-				if dataType == jsonparser.String {
-					quotedStr := strconv.Quote(string(field))
-					field = []byte(quotedStr)
-				}
-				if maxRequest.User.Ext == nil {
-					maxRequest.User.Ext = json.RawMessage("{}")
-				}
-				maxRequest.User.Ext, _ = jsonparser.Set(maxRequest.User.Ext, field, key)
-			}
-		} else {
-			// Don’t pass sessionduration and impdepth parameter if present in the request
-			maxRequest.User.Ext = jsonparser.Delete(maxRequest.User.Ext, key)
-		}
+	if maxRequest.User.Ext != nil {
+		// Don’t pass sessionduration and impdepth parameter if present in the request
+		maxRequest.User.Ext = jsonparser.Delete(maxRequest.User.Ext, "sessionduration")
+		maxRequest.User.Ext = jsonparser.Delete(maxRequest.User.Ext, "impdepth")
 	}
-
-	maxRequest.User.Ext = setIfKeysExists(signalUser.Ext, maxRequest.User.Ext, "consent", "eids")
+	//Pass user.ext.sessionduration and user.ext.impdepth to ow partners in case of ALMAX integration
+	maxRequest.User.Ext = setIfKeysExists(signalUser.Ext, maxRequest.User.Ext, "consent", "eids", "sessionduration", "impdepth")
 }
 
 func setIfKeysExists(source []byte, target []byte, keys ...string) []byte {

--- a/modules/pubmatic/openwrap/applovinmax.go
+++ b/modules/pubmatic/openwrap/applovinmax.go
@@ -187,6 +187,21 @@ func updateUser(signalUser *openrtb2.User, maxRequest *openrtb2.BidRequest) {
 	}
 
 	maxRequest.User.Data = signalUser.Data
+
+	keys := []string{"sessionduration", "impdepth"}
+
+	for _, key := range keys {
+		if field, dataType, _, err := jsonparser.Get(signalUser.Ext, key); err == nil {
+			if dataType == jsonparser.String {
+				quotedStr := strconv.Quote(string(field))
+				field = []byte(quotedStr)
+			}
+			maxRequest.User.Ext, _ = jsonparser.Set(maxRequest.User.Ext, field, key)
+		} else {
+			maxRequest.User.Ext = jsonparser.Delete(maxRequest.User.Ext, key)
+		}
+	}
+
 	maxRequest.User.Ext = setIfKeysExists(signalUser.Ext, maxRequest.User.Ext, "consent", "eids", "sessionduration", "impdepth")
 }
 

--- a/modules/pubmatic/openwrap/applovinmax.go
+++ b/modules/pubmatic/openwrap/applovinmax.go
@@ -188,6 +188,7 @@ func updateUser(signalUser *openrtb2.User, maxRequest *openrtb2.BidRequest) {
 
 	maxRequest.User.Data = signalUser.Data
 
+	//Pass user.ext.sessionduration and user.ext.impdepth to ow partners in case of ALMAX integration
 	keys := []string{"sessionduration", "impdepth"}
 
 	for _, key := range keys {
@@ -203,6 +204,7 @@ func updateUser(signalUser *openrtb2.User, maxRequest *openrtb2.BidRequest) {
 				maxRequest.User.Ext, _ = jsonparser.Set(maxRequest.User.Ext, field, key)
 			}
 		} else {
+			// Don’t pass sessionduration and impdepth parameter if present in the request
 			maxRequest.User.Ext = jsonparser.Delete(maxRequest.User.Ext, key)
 		}
 	}

--- a/modules/pubmatic/openwrap/applovinmax.go
+++ b/modules/pubmatic/openwrap/applovinmax.go
@@ -192,17 +192,22 @@ func updateUser(signalUser *openrtb2.User, maxRequest *openrtb2.BidRequest) {
 
 	for _, key := range keys {
 		if field, dataType, _, err := jsonparser.Get(signalUser.Ext, key); err == nil {
-			if dataType == jsonparser.String {
-				quotedStr := strconv.Quote(string(field))
-				field = []byte(quotedStr)
+			if field != nil {
+				if dataType == jsonparser.String {
+					quotedStr := strconv.Quote(string(field))
+					field = []byte(quotedStr)
+				}
+				if maxRequest.User.Ext == nil {
+					maxRequest.User.Ext = json.RawMessage("{}")
+				}
+				maxRequest.User.Ext, _ = jsonparser.Set(maxRequest.User.Ext, field, key)
 			}
-			maxRequest.User.Ext, _ = jsonparser.Set(maxRequest.User.Ext, field, key)
 		} else {
 			maxRequest.User.Ext = jsonparser.Delete(maxRequest.User.Ext, key)
 		}
 	}
 
-	maxRequest.User.Ext = setIfKeysExists(signalUser.Ext, maxRequest.User.Ext, "consent", "eids", "sessionduration", "impdepth")
+	maxRequest.User.Ext = setIfKeysExists(signalUser.Ext, maxRequest.User.Ext, "consent", "eids")
 }
 
 func setIfKeysExists(source []byte, target []byte, keys ...string) []byte {

--- a/modules/pubmatic/openwrap/applovinmax_test.go
+++ b/modules/pubmatic/openwrap/applovinmax_test.go
@@ -453,7 +453,7 @@ func TestUpdateUser(t *testing.T) {
 				signalUser: &openrtb2.User{ID: "sdkID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":40,"impdepth":10,"consent":"consent_string"}`)},
 				maxRequest: &openrtb2.BidRequest{User: &openrtb2.User{ID: "maxID", Yob: 2000, Gender: "F", Keywords: "k52=v43"}},
 			},
-			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":40,"impdepth":10,"consent":"consent_string"}`)},
+			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"consent":"consent_string","sessionduration":40,"impdepth":10}`)},
 		},
 		{
 			name: "signalUserExt_has_invalid_sessionduration_and_impdepth_with_consent",
@@ -461,7 +461,7 @@ func TestUpdateUser(t *testing.T) {
 				signalUser: &openrtb2.User{ID: "sdkID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":-40,"impdepth":-10,"consent":"consent_string"}`)},
 				maxRequest: &openrtb2.BidRequest{User: &openrtb2.User{ID: "maxID", Yob: 2000, Gender: "F", Keywords: "k52=v43"}},
 			},
-			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":-40,"impdepth":-10,"consent":"consent_string"}`)},
+			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"consent":"consent_string","sessionduration":-40,"impdepth":-10}`)},
 		},
 		{
 			name: "request_has_sessionduration_and_impdepth_with_consent",

--- a/modules/pubmatic/openwrap/applovinmax_test.go
+++ b/modules/pubmatic/openwrap/applovinmax_test.go
@@ -440,6 +440,30 @@ func TestUpdateUser(t *testing.T) {
 			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"consent":"consent_string","eids":[{"source":"amxid","uids":[{"atype":1,"id":"88de601e-3d98-48e7-81d7-00000000"}]},{"source":"adserver.org","uids":[{"id":"1234567","ext":{"rtiPartner":"TDID"}}]}]}`)},
 		},
 		{
+			name: "signalUserExt_and_request_both_has_sessionduration_and_impdepth",
+			args: args{
+				signalUser: &openrtb2.User{ID: "sdkID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":40,"impdepth":10}`)},
+				maxRequest: &openrtb2.BidRequest{User: &openrtb2.User{ID: "maxID", Yob: 2000, Gender: "F", Keywords: "k52=v43", Ext: json.RawMessage(`{"sessionduration":50,"impdepth":15}`)}},
+			},
+			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":40,"impdepth":10}`)},
+		},
+		{
+			name: "signalUserExt_has_invalid_and_request_has_valid_sessionduration_and_impdepth",
+			args: args{
+				signalUser: &openrtb2.User{ID: "sdkID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":-40,"impdepth":"impdepth"}`)},
+				maxRequest: &openrtb2.BidRequest{User: &openrtb2.User{ID: "maxID", Yob: 2000, Gender: "F", Keywords: "k52=v43", Ext: json.RawMessage(`{"sessionduration":50,"impdepth":15}`)}},
+			},
+			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":-40,"impdepth":"impdepth"}`)},
+		},
+		{
+			name: "request_has_sessionduration_and_impdepth",
+			args: args{
+				signalUser: &openrtb2.User{ID: "sdkID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2"},
+				maxRequest: &openrtb2.BidRequest{User: &openrtb2.User{ID: "maxID", Yob: 2000, Gender: "F", Keywords: "k52=v43", Ext: json.RawMessage(`{"sessionduration":50,"impdepth":15}`)}},
+			},
+			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{}`)},
+		},
+		{
 			name: "signalUserExt has sessionduration and impdepth",
 			args: args{
 				signalUser: &openrtb2.User{ID: "sdkID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":40,"impdepth":10}`)},

--- a/modules/pubmatic/openwrap/applovinmax_test.go
+++ b/modules/pubmatic/openwrap/applovinmax_test.go
@@ -448,10 +448,50 @@ func TestUpdateUser(t *testing.T) {
 			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":40,"impdepth":10}`)},
 		},
 		{
+			name: "signalUserExt_has_sessionduration_and_impdepth_with_consent",
+			args: args{
+				signalUser: &openrtb2.User{ID: "sdkID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":40,"impdepth":10,"consent":"consent_string"}`)},
+				maxRequest: &openrtb2.BidRequest{User: &openrtb2.User{ID: "maxID", Yob: 2000, Gender: "F", Keywords: "k52=v43"}},
+			},
+			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":40,"impdepth":10,"consent":"consent_string"}`)},
+		},
+		{
+			name: "signalUserExt_has_invalid_sessionduration_and_impdepth_with_consent",
+			args: args{
+				signalUser: &openrtb2.User{ID: "sdkID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":-40,"impdepth":-10,"consent":"consent_string"}`)},
+				maxRequest: &openrtb2.BidRequest{User: &openrtb2.User{ID: "maxID", Yob: 2000, Gender: "F", Keywords: "k52=v43"}},
+			},
+			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":-40,"impdepth":-10,"consent":"consent_string"}`)},
+		},
+		{
+			name: "request_has_sessionduration_and_impdepth_with_consent",
+			args: args{
+				signalUser: &openrtb2.User{ID: "sdkID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"consent":"consent_string"}`)},
+				maxRequest: &openrtb2.BidRequest{User: &openrtb2.User{ID: "maxID", Yob: 2000, Gender: "F", Keywords: "k52=v43"}, Ext: json.RawMessage(`{"sessionduration":40,"impdepth":10,"consent":"consent_string1"}`)},
+			},
+			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"consent":"consent_string"}`)},
+		},
+		{
+			name: "request_has_invalid_sessionduration_and_impdepth_with_consent",
+			args: args{
+				signalUser: &openrtb2.User{ID: "sdkID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"consent":"consent_string"}`)},
+				maxRequest: &openrtb2.BidRequest{User: &openrtb2.User{ID: "maxID", Yob: 2000, Gender: "F", Keywords: "k52=v43"}, Ext: json.RawMessage(`{"sessionduration":-40,"impdepth":-10,"consent":"consent_string1"}`)},
+			},
+			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"consent":"consent_string"}`)},
+		},
+		{
 			name: "signalUserExt_has_invalid_and_request_has_valid_sessionduration_and_impdepth",
 			args: args{
 				signalUser: &openrtb2.User{ID: "sdkID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":-40,"impdepth":"impdepth"}`)},
 				maxRequest: &openrtb2.BidRequest{User: &openrtb2.User{ID: "maxID", Yob: 2000, Gender: "F", Keywords: "k52=v43", Ext: json.RawMessage(`{"sessionduration":50,"impdepth":15}`)}},
+			},
+			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":-40,"impdepth":"impdepth"}`)},
+		},
+		{
+			name: "signalUserExt_has_invalid_sessionduration_and_impdepth",
+			args: args{
+				signalUser: &openrtb2.User{ID: "sdkID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":-40,"impdepth":"impdepth"}`)},
+				maxRequest: &openrtb2.BidRequest{User: &openrtb2.User{ID: "maxID", Yob: 2000, Gender: "F", Keywords: "k52=v43"}},
 			},
 			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":-40,"impdepth":"impdepth"}`)},
 		},
@@ -464,7 +504,7 @@ func TestUpdateUser(t *testing.T) {
 			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{}`)},
 		},
 		{
-			name: "signalUserExt has sessionduration and impdepth",
+			name: "signalUserExt_has_sessionduration_and_impdepth",
 			args: args{
 				signalUser: &openrtb2.User{ID: "sdkID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":40,"impdepth":10}`)},
 				maxRequest: &openrtb2.BidRequest{User: &openrtb2.User{ID: "maxID", Yob: 2000, Gender: "F", Keywords: "k52=v43"}},
@@ -472,7 +512,7 @@ func TestUpdateUser(t *testing.T) {
 			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":40,"impdepth":10}`)},
 		},
 		{
-			name: "signalUserExt has invalid sessionduration and impdepth",
+			name: "signalUserExt_has_string_type_sessionduration_and_impdepth",
 			args: args{
 				signalUser: &openrtb2.User{ID: "sdkID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":"sessionduration","impdepth":"impdepth"}`)},
 				maxRequest: &openrtb2.BidRequest{User: &openrtb2.User{ID: "maxID", Yob: 2000, Gender: "F", Keywords: "k52=v43"}},
@@ -480,7 +520,15 @@ func TestUpdateUser(t *testing.T) {
 			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":"sessionduration","impdepth":"impdepth"}`)},
 		},
 		{
-			name: "signalUserExt has sessionduration",
+			name: "signalUserExt_has_zero_sessionduration_and_impdepth",
+			args: args{
+				signalUser: &openrtb2.User{ID: "sdkID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":0,"impdepth":0}`)},
+				maxRequest: &openrtb2.BidRequest{User: &openrtb2.User{ID: "maxID", Yob: 2000, Gender: "F", Keywords: "k52=v43"}},
+			},
+			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":0,"impdepth":0}`)},
+		},
+		{
+			name: "signalUserExt_has_sessionduration",
 			args: args{
 				signalUser: &openrtb2.User{ID: "sdkID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":40}`)},
 				maxRequest: &openrtb2.BidRequest{User: &openrtb2.User{ID: "maxID", Yob: 2000, Gender: "F", Keywords: "k52=v43"}},
@@ -488,7 +536,7 @@ func TestUpdateUser(t *testing.T) {
 			want: &openrtb2.User{ID: "maxID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"sessionduration":40}`)},
 		},
 		{
-			name: "signalUserExt has impdepth",
+			name: "signalUserExt_has_impdepth",
 			args: args{
 				signalUser: &openrtb2.User{ID: "sdkID", Yob: 1999, Gender: "M", Keywords: "k1=v2;k2=v2", Ext: json.RawMessage(`{"impdepth":10}`)},
 				maxRequest: &openrtb2.BidRequest{User: &openrtb2.User{ID: "maxID", Yob: 2000, Gender: "F", Keywords: "k52=v43"}},


### PR DESCRIPTION
UOE-11360: Use sessionduration and impdepth from signal only, ignore if present in request user extension