### PR TITLE
UOE-11484: fixing invalid vast xml for spaces in pricing node

### DIFF
--- a/adapters/vastbidder/etree_parser_test.go
+++ b/adapters/vastbidder/etree_parser_test.go
@@ -331,6 +331,12 @@ func getPricingDetailsTestCases() []struct {
 			wantCurrency: "USD",
 		},
 		{
+			name:         "vast_with_whitespace_cdata_pricing",
+			vastXML:      `<VAST version="3.0"><Ad><Wrapper><Pricing>  <![CDATA[ 12.05 ]]>  </Pricing></Wrapper></Ad></VAST>`,
+			wantPrice:    12.05,
+			wantCurrency: "USD",
+		},
+		{
 			name:         "vast_gt_2.x_pricing",
 			vastXML:      `<VAST version="3.0"><Ad><Wrapper><Pricing>12.05</Pricing></Wrapper></Ad></VAST>`,
 			wantPrice:    12.05,

--- a/modules/pubmatic/openwrap/tracker/video.go
+++ b/modules/pubmatic/openwrap/tracker/video.go
@@ -128,7 +128,7 @@ func InjectPricingNodeInVAST(parent *etree.Element, price float64, model string,
 
 func updatePricingNode(node *etree.Element, price float64, model string, currency string) {
 	//Update Price
-
+	node.Child = nil
 	node.SetText(fmt.Sprintf("%v", price))
 
 	//Update Pricing.Model

--- a/modules/pubmatic/openwrap/tracker/video_test.go
+++ b/modules/pubmatic/openwrap/tracker/video_test.go
@@ -701,6 +701,26 @@ func Test_updatePricingNode(t *testing.T) {
 			},
 			want: `<Pricing model="` + models.VideoPricingModelCPM + `" currency="` + models.VideoPricingCurrencyUSD + `"><![CDATA[1.2]]></Pricing>`,
 		},
+		{
+			name: "adding_space_in_price",
+			args: args{
+				doc:      getXMLDocument(`<Pricing>  4.5  </Pricing>`),
+				price:    1.2,
+				model:    "",
+				currency: "",
+			},
+			want: `<Pricing model="` + models.VideoPricingModelCPM + `" currency="` + models.VideoPricingCurrencyUSD + `"><![CDATA[1.2]]></Pricing>`,
+		},
+		{
+			name: "adding_space_in_price_with_cdata",
+			args: args{
+				doc:      getXMLDocument(`<Pricing>  <![CDATA[4.5]]>  </Pricing>`),
+				price:    1.2,
+				model:    "",
+				currency: "",
+			},
+			want: `<Pricing model="` + models.VideoPricingModelCPM + `" currency="` + models.VideoPricingCurrencyUSD + `"><![CDATA[1.2]]></Pricing>`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
