### PR TITLE
UOE-11628: Fix: Invalid Price value added in VAST version more than 3.0

### DIFF
--- a/adapters/vastbidder/etree_parser.go
+++ b/adapters/vastbidder/etree_parser.go
@@ -57,13 +57,7 @@ func (p *etreeXMLParser) Parse(vastXML []byte) (err error) {
 }
 
 func (p *etreeXMLParser) GetPricingDetails() (price float64, currency string) {
-	var node *etree.Element
-
-	if int(p.vastVersion) == 2 {
-		node = p.adElement.FindElement("./Extensions/Extension/Price")
-	} else {
-		node = p.adElement.SelectElement("Pricing")
-	}
+	node := p.getPricingNode()
 
 	if node == nil {
 		return 0.0, ""
@@ -79,6 +73,18 @@ func (p *etreeXMLParser) GetPricingDetails() (price float64, currency string) {
 	}
 
 	return priceValue, currency
+}
+
+func (p *etreeXMLParser) getPricingNode() *etree.Element {
+	node := p.adElement.SelectElement("Pricing")
+	if node == nil {
+		node = p.adElement.FindElement("./Extensions/Extension/Pricing")
+	}
+	if node == nil {
+		node = p.adElement.FindElement("./Extensions/Extension/Price")
+	}
+
+	return node
 }
 
 func (p *etreeXMLParser) GetAdvertiser() (advertisers []string) {

--- a/adapters/vastbidder/fastxml_parser.go
+++ b/adapters/vastbidder/fastxml_parser.go
@@ -58,13 +58,7 @@ func (p *fastXMLParser) Parse(vastXML []byte) (err error) {
 }
 
 func (p *fastXMLParser) GetPricingDetails() (price float64, currency string) {
-	var node *fastxml.Element
-
-	if int(p.vastVersion) == 2 {
-		node = p.reader.SelectElement(p.adElement, "Extensions", "Extension", "Price")
-	} else {
-		node = p.reader.SelectElement(p.adElement, "Pricing")
-	}
+	node := p.getPricingNode()
 
 	if node == nil {
 		return 0.0, ""
@@ -80,6 +74,18 @@ func (p *fastXMLParser) GetPricingDetails() (price float64, currency string) {
 	}
 
 	return priceValue, currency
+}
+
+func (p *fastXMLParser) getPricingNode() *fastxml.Element {
+	node := p.reader.SelectElement(p.adElement, "Pricing")
+	if node == nil {
+		node = p.reader.SelectElement(p.adElement, "Extensions", "Extension", "Pricing")
+	}
+	if node == nil {
+		node = p.reader.SelectElement(p.adElement, "Extensions", "Extension", "Price")
+	}
+
+	return node
 }
 
 func (p *fastXMLParser) GetAdvertiser() (advertisers []string) {

--- a/adapters/vastbidder/fastxml_parser_test.go
+++ b/adapters/vastbidder/fastxml_parser_test.go
@@ -2,6 +2,7 @@ package vastbidder
 
 import (
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -68,6 +69,25 @@ func Test_fastXMLParser_GetPricingDetails(t *testing.T) {
 			gotPrice, gotCurrency := parser.GetPricingDetails()
 			assert.Equal(t, tt.wantPrice, gotPrice)
 			assert.Equal(t, tt.wantCurrency, gotCurrency)
+		})
+	}
+}
+
+func Test_fastXMLParser_getPricingNode(t *testing.T) {
+	for _, tt := range getPricingNodeTestCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := newFastXMLParser()
+			err := parser.Parse([]byte(tt.vastXML))
+			if !assert.NoError(t, err) {
+				return
+			}
+			node := parser.getPricingNode()
+			if tt.wantNil {
+				assert.Nil(t, node)
+			} else {
+				assert.NotNil(t, node)
+				assert.Equal(t, tt.wantPrice, strings.TrimSpace(parser.reader.RawText(node)))
+			}
 		})
 	}
 }


### PR DESCRIPTION
Currently, when retrieving pricing details, we are checking the /Extensions/Extension/Price and Pricing attributes in the VAST XML. We need to also support /Extensions/Extension/Pricing to handle all cases where the pricing node might be present. The priority should be: first, check for the root-level Pricing attribute, then /Extensions/Extension/Pricing, and finally /Extensions/Extension/Price, without depending on any specific VAST version.