### PR TITLE
Bump Go version from 1.21 to 1.23 in go.mod

### DIFF
--- a/.github/workflows/adapter-code-coverage.yml
+++ b/.github/workflows/adapter-code-coverage.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.3
+          go-version: 1.23
 
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/validate-merge.yml
+++ b/.github/workflows/validate-merge.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.3
+        go-version: 1.23
 
     - name: Checkout Merged Branch
       uses: actions/checkout@v4

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,7 +16,7 @@ jobs:
   validate:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x]
+        go-version: [1.23.x]
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/PubMatic-OpenWrap/prebid-server/v2
 
-go 1.21
+go 1.23
 
 replace git.pubmatic.com/vastunwrap => git.pubmatic.com/PubMatic/vastunwrap v0.0.0-20250305121837-361521441322
 


### PR DESCRIPTION
# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
