### PR TITLE
Disable country level filtering for adUnits onboarded in MBMF Phase 1

### DIFF
--- a/modules/pubmatic/openwrap/cache/cache.go
+++ b/modules/pubmatic/openwrap/cache/cache.go
@@ -22,6 +22,7 @@ type Cache interface {
 	GetAppSubIntegrationPaths() (map[string]int, error)
 	GetGDPRCountryCodes() (models.HashSet, error)
 	GetProfileAdUnitMultiFloors() (models.ProfileAdUnitMultiFloors, error)
+	GetMBMFPhase1PubId() (map[int]struct{}, error)
 
 	Set(key string, value interface{})
 	Get(key string) (interface{}, bool)

--- a/modules/pubmatic/openwrap/cache/gocache/mbmf.go
+++ b/modules/pubmatic/openwrap/cache/gocache/mbmf.go
@@ -15,3 +15,14 @@ func (c *cache) GetProfileAdUnitMultiFloors() (models.ProfileAdUnitMultiFloors, 
 	}
 	return profileAdUnitMultiFloors, nil
 }
+
+// GetMBMFPhase1PubId returns phase1pubidmultifloors fetched from DB which will be saved in publisherFeatureMap
+func (c *cache) GetMBMFPhase1PubId() (map[int]struct{}, error) {
+	pubIdMultiFloors, err := c.db.GetMBMFPhase1PubId()
+	if err != nil {
+		c.metricEngine.RecordDBQueryFailure(models.MBMFPhase1PubIdQuery, "", "")
+		glog.Errorf(models.ErrDBQueryFailed, models.MBMFPhase1PubIdQuery, "", "", err)
+		return pubIdMultiFloors, err
+	}
+	return pubIdMultiFloors, nil
+}

--- a/modules/pubmatic/openwrap/cache/mock/mock.go
+++ b/modules/pubmatic/openwrap/cache/mock/mock.go
@@ -141,6 +141,21 @@ func (mr *MockCacheMockRecorder) GetGDPRCountryCodes() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGDPRCountryCodes", reflect.TypeOf((*MockCache)(nil).GetGDPRCountryCodes))
 }
 
+// GetMBMFPhase1PubId mocks base method.
+func (m *MockCache) GetMBMFPhase1PubId() (map[int]struct{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMBMFPhase1PubId")
+	ret0, _ := ret[0].(map[int]struct{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMBMFPhase1PubId indicates an expected call of GetMBMFPhase1PubId.
+func (mr *MockCacheMockRecorder) GetMBMFPhase1PubId() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMBMFPhase1PubId", reflect.TypeOf((*MockCache)(nil).GetMBMFPhase1PubId))
+}
+
 // GetMappingsFromCacheV25 mocks base method.
 func (m *MockCache) GetMappingsFromCacheV25(arg0 models.RequestCtx, arg1 int) map[string]models.SlotMapping {
 	m.ctrl.T.Helper()

--- a/modules/pubmatic/openwrap/config/config.go
+++ b/modules/pubmatic/openwrap/config/config.go
@@ -82,6 +82,7 @@ type Queries struct {
 	GetGDPRCountryCodes               string
 	GetBannerSizesQuery               string
 	GetProfileAdUnitMultiFloors       string
+	GetMBMFPhase1PubId                string
 }
 
 type Cache struct {

--- a/modules/pubmatic/openwrap/database/database.go
+++ b/modules/pubmatic/openwrap/database/database.go
@@ -21,4 +21,5 @@ type Database interface {
 	GetAppSubIntegrationPaths() (map[string]int, error)
 	GetGDPRCountryCodes() (models.HashSet, error)
 	GetProfileAdUnitMultiFloors() (models.ProfileAdUnitMultiFloors, error)
+	GetMBMFPhase1PubId() (map[int]struct{}, error)
 }

--- a/modules/pubmatic/openwrap/database/mock/mock.go
+++ b/modules/pubmatic/openwrap/database/mock/mock.go
@@ -245,3 +245,18 @@ func (mr *MockDatabaseMockRecorder) GetWrapperSlotMappings(arg0, arg1, arg2 inte
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWrapperSlotMappings", reflect.TypeOf((*MockDatabase)(nil).GetWrapperSlotMappings), arg0, arg1, arg2)
 }
+
+// GetMBMFPhase1PubId mocks base method.
+func (m *MockDatabase) GetMBMFPhase1PubId() (map[int]struct{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMBMFPhase1PubId")
+	ret0, _ := ret[0].(map[int]struct{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMBMFPhase1PubId indicates an expected call of GetMBMFPhase1PubId.
+func (mr *MockDatabaseMockRecorder) GetMBMFPhase1PubId() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMBMFPhase1PubId", reflect.TypeOf((*MockDatabase)(nil).GetMBMFPhase1PubId))
+}

--- a/modules/pubmatic/openwrap/database/mysql/mbmf.go
+++ b/modules/pubmatic/openwrap/database/mysql/mbmf.go
@@ -48,3 +48,32 @@ func (db *mySqlDB) GetProfileAdUnitMultiFloors() (models.ProfileAdUnitMultiFloor
 	}
 	return profileAdUnitMultiFloors, nil
 }
+
+func (db *mySqlDB) GetMBMFPhase1PubId() (map[int]struct{}, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(time.Millisecond*time.Duration(db.cfg.MaxDbContextTimeout)))
+	defer cancel()
+
+	rows, err := db.conn.QueryContext(ctx, db.cfg.Queries.GetMBMFPhase1PubId)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var (
+		pubId int
+		// map to store the pubIds
+		pubIds = make(map[int]struct{})
+	)
+	for rows.Next() {
+		if err := rows.Scan(&pubId); err != nil {
+			glog.Errorf(models.ErrDBRowScanFailed, models.MBMFPhase1PubIdQuery, "", "", err.Error())
+			continue
+		}
+		pubIds[pubId] = struct{}{}
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return pubIds, nil
+}

--- a/modules/pubmatic/openwrap/models/constants.go
+++ b/modules/pubmatic/openwrap/models/constants.go
@@ -560,6 +560,7 @@ const (
 	AppSubIntegrationPathMapQuery = "GetAppSubIntegrationPathMapQuery"
 	GDPRCountryCodesQuery         = "GetGDPRCountryCodes"
 	ProfileAdUnitMultiFloorsQuery = "GetProfileAdUnitMultiFloors"
+	MBMFPhase1PubIdQuery          = "GetMBMFPhase1PubId"
 )
 
 // constants for owlogger Integration Type

--- a/modules/pubmatic/openwrap/publisherfeature/feature.go
+++ b/modules/pubmatic/openwrap/publisherfeature/feature.go
@@ -18,4 +18,5 @@ type Feature interface {
 	IsMBMFEnabledForAdUnitFormat(pubID int, adUnitFormat string) bool
 	GetMBMFFloorsForAdUnitFormat(pubID int, adUnitFormat string) *models.MultiFloors
 	GetProfileAdUnitMultiFloors(profileID int) map[string]*models.MultiFloors
+	IsPubIdMBMFPhase1Enabled(pubID int) bool
 }

--- a/modules/pubmatic/openwrap/publisherfeature/mbmf.go
+++ b/modules/pubmatic/openwrap/publisherfeature/mbmf.go
@@ -24,6 +24,10 @@ type mbmf struct {
 	index atomic.Int32
 }
 
+type mbmfPhase1PubId struct {
+	enabledPublishers map[int]struct{}
+}
+
 func newMBMF() *mbmf {
 	m := mbmf{
 		data: [2]mbmfData{
@@ -210,4 +214,19 @@ func extractMultiFloors(featureMap map[int]models.FeatureData, featureKey int, p
 		return &floors
 	}
 	return nil
+}
+
+func (fe *feature) updateMBMFPhase1PubId() {
+	pubIdMultiFloors, err := fe.cache.GetMBMFPhase1PubId()
+	if err != nil || pubIdMultiFloors == nil {
+		return
+	}
+	// assign fetched pubIds to the inactive map
+	fe.mbmfPhase1PubId.enabledPublishers = pubIdMultiFloors
+}
+
+// IsPubIdMBMFPhase1Enabled returns true if pubId is multi-floors enabled
+func (fe *feature) IsPubIdMBMFPhase1Enabled(pubId int) bool {
+	_, enabled := fe.mbmfPhase1PubId.enabledPublishers[pubId]
+	return enabled
 }

--- a/modules/pubmatic/openwrap/publisherfeature/mock/mock.go
+++ b/modules/pubmatic/openwrap/publisherfeature/mock/mock.go
@@ -105,7 +105,6 @@ func (mr *MockFeatureMockRecorder) GetMBMFPhase1PubId() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMBMFPhase1PubId", reflect.TypeOf((*MockFeature)(nil).GetMBMFPhase1PubId))
 }
 
-
 // IsAmpMultiformatEnabled mocks base method.
 func (m *MockFeature) IsAmpMultiformatEnabled(arg0 int) bool {
 	m.ctrl.T.Helper()
@@ -226,7 +225,6 @@ func (m *MockFeature) IsMBMFPublisherEnabled(arg0 int) bool {
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
-
 
 // IsPubIdMBMFPhase1Enabled mocks base method.
 func (m *MockFeature) IsPubIdMBMFPhase1Enabled(arg0 int) bool {

--- a/modules/pubmatic/openwrap/publisherfeature/mock/mock.go
+++ b/modules/pubmatic/openwrap/publisherfeature/mock/mock.go
@@ -90,6 +90,22 @@ func (mr *MockFeatureMockRecorder) GetProfileAdUnitMultiFloors(arg0 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProfileAdUnitMultiFloors", reflect.TypeOf((*MockFeature)(nil).GetProfileAdUnitMultiFloors), arg0)
 }
 
+// GetMBMFPhase1PubId mocks base method.
+func (m *MockFeature) GetMBMFPhase1PubId() (map[int]struct{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMBMFPhase1PubId")
+	ret0, _ := ret[0].(map[int]struct{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMBMFPhase1PubId indicates an expected call of GetMBMFPhase1PubId.
+func (mr *MockFeatureMockRecorder) GetMBMFPhase1PubId() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMBMFPhase1PubId", reflect.TypeOf((*MockFeature)(nil).GetMBMFPhase1PubId))
+}
+
+
 // IsAmpMultiformatEnabled mocks base method.
 func (m *MockFeature) IsAmpMultiformatEnabled(arg0 int) bool {
 	m.ctrl.T.Helper()
@@ -209,6 +225,21 @@ func (m *MockFeature) IsMBMFPublisherEnabled(arg0 int) bool {
 	ret := m.ctrl.Call(m, "IsMBMFPublisherEnabled", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
+}
+
+
+// IsPubIdMBMFPhase1Enabled mocks base method.
+func (m *MockFeature) IsPubIdMBMFPhase1Enabled(arg0 int) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsPubIdMBMFPhase1Enabled", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsPubIdMBMFPhase1Enabled indicates an expected call of IsPubIdMBMFPhase1Enabled.
+func (mr *MockFeatureMockRecorder) IsPubIdMBMFPhase1Enabled(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPubIdMBMFPhase1Enabled", reflect.TypeOf((*MockFeature)(nil).IsPubIdMBMFPhase1Enabled), arg0)
 }
 
 // IsMBMFPublisherEnabled indicates an expected call of IsMBMFPublisherEnabled.

--- a/modules/pubmatic/openwrap/publisherfeature/reloader.go
+++ b/modules/pubmatic/openwrap/publisherfeature/reloader.go
@@ -31,6 +31,7 @@ type feature struct {
 	impCountingMethod   impCountingMethod
 	gdprCountryCodes    gdprCountryCodes
 	mbmf                *mbmf
+	mbmfPhase1PubId     mbmfPhase1PubId
 }
 
 var fe *feature
@@ -66,6 +67,9 @@ func New(config Config) *feature {
 			impCountingMethod: newImpCountingMethod(),
 			gdprCountryCodes:  newGDPRCountryCodes(),
 			mbmf:              newMBMF(),
+			mbmfPhase1PubId: mbmfPhase1PubId{
+				enabledPublishers: make(map[int]struct{}),
+			},
 		}
 	})
 	return fe
@@ -127,6 +131,8 @@ func (fe *feature) updateFeatureConfigMaps() {
 	fe.updateApplovinMultiFloorsFeature()
 	fe.updateImpCountingMethodEnabledBidders()
 	fe.updateMBMF()
+	//update phase1PubIdMultiFloors
+	fe.updateMBMFPhase1PubId()
 
 	if err != nil {
 		glog.Error(err.Error())

--- a/modules/pubmatic/openwrap/util.go
+++ b/modules/pubmatic/openwrap/util.go
@@ -613,8 +613,10 @@ func (m OpenWrap) getMultiFloors(rctx models.RequestCtx, reward *int8, imp openr
 		return nil
 	}
 
-	if !m.pubFeatures.IsMBMFCountry(rctx.DeviceCtx.DerivedCountryCode) {
-		return nil
+	if !m.pubFeatures.IsPubIdMBMFPhase1Enabled(rctx.PubID) {
+		if !m.pubFeatures.IsMBMFCountry(rctx.DeviceCtx.DerivedCountryCode) {
+			return nil
+		}
 	}
 
 	//if pub entry present with is_enabled=1 AND no pub in mbmf_enabled wrapper_feature-> apply mbmf

--- a/modules/pubmatic/openwrap/util_test.go
+++ b/modules/pubmatic/openwrap/util_test.go
@@ -2233,6 +2233,7 @@ func TestOpenWrapGetMultiFloors(t *testing.T) {
 			want: nil,
 			setup: func() {
 				mockFeature.EXPECT().IsMBMFCountry("IN").Return(false)
+				mockFeature.EXPECT().IsPubIdMBMFPhase1Enabled(5890).Return(false)
 			},
 		},
 		{
@@ -2251,6 +2252,7 @@ func TestOpenWrapGetMultiFloors(t *testing.T) {
 			setup: func() {
 				mockFeature.EXPECT().IsMBMFCountry("US").Return(true)
 				mockFeature.EXPECT().IsMBMFPublisherEnabled(5890).Return(false)
+				mockFeature.EXPECT().IsPubIdMBMFPhase1Enabled(5890).Return(false)
 			},
 		},
 		{
@@ -2273,6 +2275,7 @@ func TestOpenWrapGetMultiFloors(t *testing.T) {
 				mockFeature.EXPECT().IsMBMFCountry("US").Return(true)
 				mockFeature.EXPECT().IsMBMFPublisherEnabled(5890).Return(true)
 				mockFeature.EXPECT().IsMBMFEnabledForAdUnitFormat(5890, models.AdUnitFormatInstl).Return(false)
+				mockFeature.EXPECT().IsPubIdMBMFPhase1Enabled(5890).Return(false)
 			},
 		},
 		{
@@ -2301,6 +2304,7 @@ func TestOpenWrapGetMultiFloors(t *testing.T) {
 						IsActive: false,
 					},
 				})
+				mockFeature.EXPECT().IsPubIdMBMFPhase1Enabled(5890).Return(false)
 			},
 		},
 		{
@@ -2337,6 +2341,7 @@ func TestOpenWrapGetMultiFloors(t *testing.T) {
 						Tier3:    3.1,
 					},
 				})
+				mockFeature.EXPECT().IsPubIdMBMFPhase1Enabled(5890).Return(false)
 			},
 		},
 		{
@@ -2379,6 +2384,7 @@ func TestOpenWrapGetMultiFloors(t *testing.T) {
 					Tier2:    2.1,
 					Tier3:    3.1,
 				})
+				mockFeature.EXPECT().IsPubIdMBMFPhase1Enabled(5890).Return(false)
 			},
 		},
 		{
@@ -2421,6 +2427,7 @@ func TestOpenWrapGetMultiFloors(t *testing.T) {
 					Tier2:    2,
 					Tier3:    3,
 				})
+				mockFeature.EXPECT().IsPubIdMBMFPhase1Enabled(5890).Return(false)
 			},
 		},
 		{
@@ -2455,6 +2462,7 @@ func TestOpenWrapGetMultiFloors(t *testing.T) {
 						Tier3:    3,
 					},
 				})
+				mockFeature.EXPECT().IsPubIdMBMFPhase1Enabled(5890).Return(false)
 			},
 		},
 		{
@@ -2477,6 +2485,7 @@ func TestOpenWrapGetMultiFloors(t *testing.T) {
 				mockFeature.EXPECT().IsMBMFCountry("US").Return(true)
 				mockFeature.EXPECT().IsMBMFPublisherEnabled(5890).Return(true)
 				mockFeature.EXPECT().GetProfileAdUnitMultiFloors(1234).Return(map[string]*models.MultiFloors{})
+				mockFeature.EXPECT().IsPubIdMBMFPhase1Enabled(5890).Return(false)
 			},
 		},
 	}


### PR DESCRIPTION
# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
