### PR TITLE
UOE-12574:[GoogleSDK]: Consume imp.ext.skadn.skadnetids from signal data

### DIFF
--- a/modules/pubmatic/openwrap/sdk/googlesdk/request.go
+++ b/modules/pubmatic/openwrap/sdk/googlesdk/request.go
@@ -2,7 +2,6 @@ package googlesdk
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"strconv"
 
@@ -133,7 +132,7 @@ func getWrapperData(body []byte) (*wrapperData, error) {
 	}
 
 	var adunitMapping []map[string]interface{}
-	if err := json.Unmarshal(adunitMappingByte, &adunitMapping); err != nil {
+	if err := jsoniterator.Unmarshal(adunitMappingByte, &adunitMapping); err != nil {
 		glog.Errorf("[GoogleSDK] [Error]: failed to unmarshal ad unit mapping %v", err)
 		return nil, errors.New("failed to unmarshal ad unit mapping")
 	}
@@ -190,7 +189,7 @@ func ModifyRequestWithGoogleSDKParams(requestBody []byte, rctx models.RequestCtx
 	}
 
 	sdkRequest := &openrtb2.BidRequest{}
-	if err := json.Unmarshal(requestBody, sdkRequest); err != nil {
+	if err := jsoniterator.Unmarshal(requestBody, sdkRequest); err != nil {
 		return requestBody
 	}
 
@@ -219,7 +218,7 @@ func ModifyRequestWithGoogleSDKParams(requestBody []byte, rctx models.RequestCtx
 	// Google SDK specific modifications
 	modifyRequestWithGoogleFeature(sdkRequest, features)
 
-	modifiedRequest, err := json.Marshal(sdkRequest)
+	modifiedRequest, err := jsoniterator.Marshal(sdkRequest)
 	if err != nil {
 		return requestBody
 	}
@@ -415,6 +414,7 @@ func modifyImpExtension(requestImpExt, signalImpExt []byte) []byte {
 	requestImpExt, _ = sdkutils.CopyPath(signalImpExt, requestImpExt, "skadn", "version")
 	requestImpExt, _ = sdkutils.CopyPath(signalImpExt, requestImpExt, "skadn", "skoverlay")
 	requestImpExt, _ = sdkutils.CopyPath(signalImpExt, requestImpExt, "skadn", "productpage")
+	requestImpExt, _ = sdkutils.CopyPath(signalImpExt, requestImpExt, "skadn", "skadnetids")
 	return requestImpExt
 }
 

--- a/modules/pubmatic/openwrap/sdk/googlesdk/request_test.go
+++ b/modules/pubmatic/openwrap/sdk/googlesdk/request_test.go
@@ -578,6 +578,32 @@ func TestModifyImpression(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "update skadnetids from signal",
+			request: &openrtb2.BidRequest{
+				Imp: []openrtb2.Imp{
+					{
+						ID:    "imp1",
+						TagID: "tag-123",
+						Ext:   []byte(`{"skadn":{"skadnetids":["old1", "old2"]}}`),
+					},
+				},
+			},
+			signalImps: []openrtb2.Imp{
+				{
+					Ext: []byte(`{"skadn":{"skadnetids": ["net1", "net2"]}}`),
+				},
+			},
+			expectedResult: &openrtb2.BidRequest{
+				Imp: []openrtb2.Imp{
+					{
+						ID:    "imp1",
+						TagID: "tag-123",
+						Ext:   []byte(`{"skadn":{"skadnetids":["net1", "net2"]}}`),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Description

Please add change description or link to ticket, docs, etc.

# Checklist:

- [ ] PR commit list is unique (rebase/pull with the origin branch to keep master clean).
- [ ] JIRA number is added in the PR title and the commit message.
- [ ] Updated the `header-bidding` repo with appropiate commit id.
- [ ] Documented the new changes.

For Prebid upgrade, refer: https://inside.pubmatic.com:8443/confluence/display/Products/Prebid-server+upgrade
